### PR TITLE
Fixed a couple of css issues in the vs template

### DIFF
--- a/skeletons/vstemplate/DurandalTemplate/DurandalTemplate/App_Start/BundleConfig.cs
+++ b/skeletons/vstemplate/DurandalTemplate/DurandalTemplate/App_Start/BundleConfig.cs
@@ -16,15 +16,11 @@ namespace DurandalTemplate {
         );
 
       bundles.Add(
-        new StyleBundle("~/css/vendor")
+        new StyleBundle("~/Content/css")
           .Include("~/Content/bootstrap.min.css")
+          .Include("~/Content/app.css")
           .Include("~/Content/bootstrap-responsive.min.css")
           .Include("~/Content/font-awesome.min.css")
-        );
-
-      bundles.Add(
-        new StyleBundle("~/css/app")
-          .Include("~/Content/app.css")
         );
     }
 

--- a/skeletons/vstemplate/DurandalTemplate/DurandalTemplate/Views/Home/Index.cshtml
+++ b/skeletons/vstemplate/DurandalTemplate/DurandalTemplate/Views/Home/Index.cshtml
@@ -8,8 +8,7 @@
         <link rel="apple-touch-startup-image" href="~/Content/images/ios-startup-image-portrait.png" media="(orientation:portrait)" />
         <link rel="apple-touch-icon" href="~/Content/images/icon.png"/>
         
-        @Styles.Render("~/css/vendor")
-        @Styles.Render("~/css/app")
+        @Styles.Render("~/Content/css")
         
         <meta charset="utf-8" />
         <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
Fixed issue with the sequence of loading the css files. If you load the
app.css before the bootstrap responsive it creates a weird gap at the
top of the page when you size down. Also fixed issue with the bundle not
have the correct root directory which prevents the font awesome fonts
from being downloaded when the bundling is on.
