### PR TITLE
Small change to router.js

### DIFF
--- a/App/durandal/plugins/router.js
+++ b/App/durandal/plugins/router.js
@@ -103,10 +103,7 @@
             if (fragment.length == 2) {
                 var parts = fragment[1].split('/');
                 route = parts[0];
-                var splat = parts.splice(1);
-                if (splat.length > 0) {
-                    params.splat = splat;
-                }
+                params.splat = parts.splice(1);
                 ensureRoute(route, params);
                 return;
             }


### PR DESCRIPTION
This is what I wanted.  I didn't realize it till I started playing with it some but basically I didn't like how the splat object was being populated w/ the module name sometimes and at other times it would just be the parameters.

This was causing me to check for the module name inside each of my modules that interrogated the splat object.

Also, I'm overriding the [`router.autoConvertRouteToModuleId(route, params)`](https://github.com/BlueSpire/Durandal/blob/master/App/durandal/plugins/router.js#L73) like so:

```
router.autoConvertRouteToModuleId = function(url) {
  return 'areas/' + url + '/index';
}
```

I didn't see this method documented in your Wiki but I'm hoping I'm using it as you intended.

Thanks,
Evan
