### PR TITLE
Fixed KnockoutJS template that wont work

### DIFF
--- a/App/durandal/modalDialog.js
+++ b/App/durandal/modalDialog.js
@@ -146,7 +146,8 @@
 
             $child.css({
                 'margin-top': (-height / 2).toString() + 'px',
-                'margin-left': (-width / 2).toString() + 'px'
+                'margin-left': (-width / 2).toString() + 'px',
+                display: 'block'
             });
 
             $(settings.model.modal.host).css('opacity', 1);

--- a/App/durandal/viewEngine.js
+++ b/App/durandal/viewEngine.js
@@ -50,7 +50,7 @@
 
             return system.defer(function(dfd) {
                 system.acquire(requirePath).then(function(markup) {
-                    var element = that.parseMarkup(markup);
+                    var element = $(that.parseMarkup(markup)).hide().appendTo('body').get(0);
                     element.setAttribute('data-view', viewId);
                     dfd.resolve(element);
                 });


### PR DESCRIPTION
Hi Rob,

I've been using knockoutJS template inside composite view and its not working. On the browser console keep saying "Cannot find template with ID ...." Then I tried to fix it by append the element into body before bind it (on viewEngine.js) and its working fine -- I just thinking that KnockoutJS can't recognize script template if the element is never landing into body. 

This workaround is has affect on modalDialog.js that will never appear anymore, because I hide it first to avoid showing element twice on activation, so I ensure that every child on modalDialog is always has style `display:block`.

Am I in correct path? Or this is actually bug? To reproduce the issue you can check my code on this branch: https://github.com/budiadiono/DurandalMovieApp/tree/TemplateProblem. That was modified code from Stephen Walther's blog post at http://stephenwalther.com/archive/2013/02/08/using-durandal-to-create-single-page-apps.aspx.

Thanks!
Budi
