### PR TITLE
skipTransitionOnSameView settings to skip transition within same view

### DIFF
--- a/App/durandal/composition.js
+++ b/App/durandal/composition.js
@@ -76,7 +76,8 @@
         switchContent: function (parent, newChild, settings) {
             settings.transition = settings.transition || this.defaultTransitionName;
 
-            if (typeof settings.transition == 'string' && newChild) {
+            if (typeof settings.transition == 'string' && newChild &&
+                (!settings.skipTransitionOnSameView || settings.skipTransitionOnSameView == true && newChild != settings.activeView)) {
                 var transitionModuleId = this.convertTransitionToModuleId(settings.transition);
                 system.acquire(transitionModuleId).then(function (transition) {
                     settings.transition = transition;


### PR DESCRIPTION
Try to resolve issue discussed on https://groups.google.com/forum/#!topic/durandaljs/LlFYkgbeehY.

On your shell, put `skipTransitionOnSameView: true` inside compose binding parameter, looks like this:

```
<!--ko compose: { 
        model: router.activeItem, //wiring the router
        afterCompose: router.afterCompose, //wiring the router
        transition:'entrance', //use the 'entrance' transition when switching views
        cacheViews:true, //telling composition to keep views in the dom, and reuse them (only a good idea with singleton view models)
        skipTransitionOnSameView: true
    }--><!--/ko-->
```

That will makes activate module item within same view not causing transition to be played. 
