### PR TITLE
Added title property to app module

### DIFF
--- a/App/durandal/app.js
+++ b/App/durandal/app.js
@@ -6,9 +6,12 @@
         modalDialog = require('./modalDialog'),
         Events = require('./events');
 
-    var MessageBox;
+    var MessageBox,
+        defaultTitle = 'Application';
 
     var app = {
+        title: defaultTitle,
+
         showModal: function(obj, activationData, context) {
             return modalDialog.show(obj, activationData, context);
         },
@@ -16,11 +19,17 @@
             return modalDialog.show(new MessageBox(message, title, options));
         },
         start: function() {
+            var that = this;
+            if (that.title) {
+                document.title = that.title;
+            }
+
             return system.defer(function (dfd) {
                 $(function() {
                     system.log('Starting Application');
                     system.acquire('./messageBox').then(function(mb) {
                         MessageBox = mb;
+                        MessageBox.defaultTitle = that.title || defaultTitle;
                         dfd.resolve();
                         system.log('Started Application');
                     });

--- a/App/durandal/messageBox.js
+++ b/App/durandal/messageBox.js
@@ -9,7 +9,7 @@
         this.modal.close(dialogResult);
     };
 
-    MessageBox.defaultTitle = 'Application';
+    MessageBox.defaultTitle = '';
     MessageBox.defaultOptions = ['Ok'];
 
     return MessageBox;


### PR DESCRIPTION
I've added a Title property to the app module.
This property is used by Durandal as the default title for messageboxes.
Also it is used to set the document title so we have a title before the router sets it.

Furthermore one could use this property to bind it to an html element. For example to bind it to the navbar > brand > span as seen in the Durandal starterkit.

With this title property one can reduce the number of places where the actual app title is declared. I reduced it from 5 times to only 2 (setting app.title in main.js and having it in the _splash.html)
