### PR TITLE
Include activationData in viewModel.beforeActivate

### DIFF
--- a/App/durandal/viewModel.js
+++ b/App/durandal/viewModel.js
@@ -227,7 +227,7 @@
                                 system.defer(function (dfd2) {
                                     deactivate(currentItem, settings.closeOnDeactivate, settings, dfd2);
                                 }).promise().then(function () {
-                                    newItem = settings.beforeActivate(newItem);
+                                    newItem = settings.beforeActivate(newItem, activationData);
                                     activate(newItem, activeItem, function (result) {
                                         computed.isActivating(false);
                                         dfd.resolve(result);


### PR DESCRIPTION
I think it would be nice if we can include `activationData` as part of `viewModel.beforeActivate` parameter. In some other case I need to calculate received parameters and inject the result into my view model. In some reason I can't use `router.onNavigationComplete` to do that, so I must override `router.activeItem.settings.beforeActivate` method so it will looks like this:

```
router.activeItem.settings.beforeActivate = function (newItem, params) {
   newItem.userPath(params.user + '/' + params.group);
   return newItem;
};
```

I made sample app on https://github.com/budiadiono/DurandalMovieApp/tree/IntuitiveUserPath. On that sample app actually is fine to use `router.onNavigationComplete` but not for my other app that I've been developing right now. What do you think?
