### PR TITLE
Prevent "popping" when transition using entrance

### DIFF
--- a/App/durandal/transitions/entrance.js
+++ b/App/durandal/transitions/entrance.js
@@ -8,11 +8,16 @@
                 dfd.resolve();
             }
 
-            if (!settings.keepScrollPosition) {
-                $(document).scrollTop(0);
+            function scrollIfNeeded()
+            {
+                if (!settings.keepScrollPosition) {
+                    $(document).scrollTop(0);
+                }
             }
 
             if (!newChild) {
+                scrollIfNeeded();
+
                 if (settings.activeView) {
                     $(settings.activeView).fadeOut(fadeOutDuration, function () {
                         if (!settings.cacheViews) {
@@ -31,6 +36,8 @@
                 var duration = settings.duration || 500;
 
                 function startTransition() {
+                    scrollIfNeeded();
+
                     if (settings.cacheViews) {
                         if (settings.composingNewView) {
                             ko.virtualElements.prepend(parent, newChild);


### PR DESCRIPTION
New to git and this is my first pull request ever, so sorry if I did something stupid ;)

Simply moved the .scrollTop code so it doesn't fire until after the old
view has faded out, which prevents a visual "pop" as the page scrolls to
the top right before starting the transition.
