### PR TITLE
router.navigateTo support for external URLs

### DIFF
--- a/App/durandal/plugins/router.js
+++ b/App/durandal/plugins/router.js
@@ -232,7 +232,11 @@
             window.history.back();
         },
         navigateTo: function (url) {
-            sammy.setLocation(url);
+            if (sammy.lookupRoute('get', url)) {
+                sammy.setLocation(url);
+            } else {
+                window.location.href = url;
+            }
         },
         replaceLocation: function (url) {
             window.location.replace(url);

--- a/skeletons/mimosa/DurandalTemplate/assets/App/durandal/plugins/router.js
+++ b/skeletons/mimosa/DurandalTemplate/assets/App/durandal/plugins/router.js
@@ -232,7 +232,11 @@
             window.history.back();
         },
         navigateTo: function (url) {
-            sammy.setLocation(url);
+            if (sammy.lookupRoute('get', url)) {
+                sammy.setLocation(url);
+            } else {
+                window.location.href = url;
+            }
         },
         replaceLocation: function (url) {
             window.location.replace(url);

--- a/skeletons/nuget/Durandal.Router/content/App/durandal/plugins/router.js
+++ b/skeletons/nuget/Durandal.Router/content/App/durandal/plugins/router.js
@@ -232,7 +232,11 @@
             window.history.back();
         },
         navigateTo: function (url) {
-            sammy.setLocation(url);
+            if (sammy.lookupRoute('get', url)) {
+                sammy.setLocation(url);
+            } else {
+                window.location.href = url;
+            }
         },
         replaceLocation: function (url) {
             window.location.replace(url);

--- a/skeletons/nuget/Durandal.Transitions/content/App/durandal/plugins/router.js
+++ b/skeletons/nuget/Durandal.Transitions/content/App/durandal/plugins/router.js
@@ -232,7 +232,11 @@
             window.history.back();
         },
         navigateTo: function (url) {
-            sammy.setLocation(url);
+            if (sammy.lookupRoute('get', url)) {
+                sammy.setLocation(url);
+            } else {
+                window.location.href = url;
+            }
         },
         replaceLocation: function (url) {
             window.location.replace(url);

--- a/skeletons/nuget/Durandal/content/App/durandal/plugins/router.js
+++ b/skeletons/nuget/Durandal/content/App/durandal/plugins/router.js
@@ -232,7 +232,11 @@
             window.history.back();
         },
         navigateTo: function (url) {
-            sammy.setLocation(url);
+            if (sammy.lookupRoute('get', url)) {
+                sammy.setLocation(url);
+            } else {
+                window.location.href = url;
+            }
         },
         replaceLocation: function (url) {
             window.location.replace(url);

--- a/skeletons/vstemplate/DurandalTemplate/DurandalTemplate/App/durandal/plugins/router.js
+++ b/skeletons/vstemplate/DurandalTemplate/DurandalTemplate/App/durandal/plugins/router.js
@@ -232,7 +232,11 @@
             window.history.back();
         },
         navigateTo: function (url) {
-            sammy.setLocation(url);
+            if (sammy.lookupRoute('get', url)) {
+                sammy.setLocation(url);
+            } else {
+                window.location.href = url;
+            }
         },
         replaceLocation: function (url) {
             window.location.replace(url);


### PR DESCRIPTION
Modify router.navigateTo to use sammy for matching routes; otherwise set window.location.href directly.  This allows programmatic navigation to be more consistent between internal and external urls
