### PR TITLE
Allow transitions to occur when there is no view to transition to

### DIFF
--- a/App/durandal/composition.js
+++ b/App/durandal/composition.js
@@ -65,7 +65,7 @@
     }
 
     function shouldTransition(newChild, settings) {
-        if (typeof settings.transition == 'string' && newChild) {
+        if (typeof settings.transition == 'string') {
             if (settings.activeView) {
                 if (settings.activeView == newChild) {
                     return false;
@@ -76,13 +76,9 @@
                     var newViewId = newChild.getAttribute('data-view');
                     return currentViewId != newViewId;
                 }
-
-                return true;
             }
-
             return true;
         }
-
         return false;
     }
 


### PR DESCRIPTION
The built-in transition already handles transitioning a view out without transitioning a new view in, but the shouldTransition function stopped it from ever being called. This commit allows shouldTransition to evaluate to true even if there is no new child.
