### PR TITLE
Use route caption instead of route name for document.title

### DIFF
--- a/App/durandal/plugins/router.js
+++ b/App/durandal/plugins/router.js
@@ -249,9 +249,9 @@
         },
         onNavigationComplete: function (routeInfo, params, module) {
             if (app.title) {
-                document.title = routeInfo.name + " | " + app.title;
+                document.title = routeInfo.caption + " | " + app.title;
             } else {
-                document.title = routeInfo.name;
+                document.title = routeInfo.caption;
             }
         },
         navigateBack: function () {


### PR DESCRIPTION
It currently uses the routeInfo.name, and the caption is never used.

Very short fix that makes me able to use name for searching for routes after.
