### PR TITLE
Use routeInfo.caption for document.title when navigating

### DIFF
--- a/App/durandal/plugins/router.js
+++ b/App/durandal/plugins/router.js
@@ -249,9 +249,9 @@
         },
         onNavigationComplete: function (routeInfo, params, module) {
             if (app.title) {
-                document.title = routeInfo.name + " | " + app.title;
+                document.title = routeInfo.caption + " | " + app.title;
             } else {
-                document.title = routeInfo.name;
+                document.title = routeInfo.caption;
             }
         },
         navigateBack: function () {


### PR DESCRIPTION
The caption of a route was never used anywhere. It is now used for
title.
