### PR TITLE
Router doesn't set caption for auto mapped routes

### DIFF
--- a/App/durandal/plugins/router.js
+++ b/App/durandal/plugins/router.js
@@ -159,9 +159,11 @@
                 return;
             }
 
+            var routeName = router.convertRouteToName(route);
             routeInfo = {
                 moduleId: router.autoConvertRouteToModuleId(route, params),
-                name: router.convertRouteToName(route)
+                name: routeName,
+                caption: routeName
             };
         }
 


### PR DESCRIPTION
When using mapAuto, the routeInfo object is missing caption property on initialization. So the document title goes undefined.

router.js lines 162-167 provides a fix.
