### PR TITLE
Buried Exceptions

### DIFF
--- a/App/durandal/system.js
+++ b/App/durandal/system.js
@@ -71,6 +71,10 @@
         } catch(ignore) {}
     };
 
+    var logError = function(error) {
+        throw error;
+    };
+
     system = {
         version:"1.2.0",
         noop: noop,
@@ -110,10 +114,12 @@
                 isDebugging = enable;
                 if (isDebugging) {
                     this.log = log;
+                    this.logError = logError;
                     this.log('Debug mode enabled.');
                 } else {
                     this.log('Debug mode disabled.');
                     this.log = noop;
+                    this.logError = noop;
                 }
             } else {
                 return isDebugging;
@@ -123,6 +129,7 @@
             return toString.call(obj) === '[object Array]';
         },
         log: noop,
+        logError: noop,
         defer: function(action) {
             return $.Deferred(action);
         },

--- a/App/durandal/viewModel.js
+++ b/App/durandal/viewModel.js
@@ -37,7 +37,7 @@
             try {
                 result = item.deactivate(close);
             } catch(error) {
-                system.log(error);
+                system.logError(error);
                 dfd.resolve(false);
                 return;
             }
@@ -72,7 +72,7 @@
                 try {
                     result = newItem.activate(activationData);
                 } catch (error) {
-                    system.log(error);
+                    system.logError(error);
                     callback(false);
                     return;
                 }
@@ -105,7 +105,7 @@
                 try {
                     resultOrPromise = item.canDeactivate(close);
                 } catch(error) {
-                    system.log(error);
+                    system.logError(error);
                     dfd.resolve(false);
                     return;
                 }
@@ -138,7 +138,7 @@
                 try {
                     resultOrPromise = newItem.canActivate(activationData);
                 } catch (error) {
-                    system.log(error);
+                    system.logError(error);
                     dfd.resolve(false);
                     return;
                 }


### PR DESCRIPTION
Calling console.log on exceptions was making very challenging to debug
errors when viewmodels were being bound. I changed it to throw the error
so the console could get a proper stack trace.
