### PR TITLE
router.navigateToRoute

### DIFF
--- a/App/durandal/plugins/router.js
+++ b/App/durandal/plugins/router.js
@@ -267,6 +267,7 @@
         navigateToRoute: function (url, data) {
 
             var newUrl = url;
+            // find the hash using the url with parameters stripped 
             for (var route in routesByPath) {
                 if (router.stripParameter(routesByPath[route].url) == url) {
                     newUrl = routesByPath[route].hash;
@@ -274,6 +275,7 @@
                 }
             }
 
+            // if this is an url with parameters, add data.property for these parameters to the url
             var colonIndex = newUrl.indexOf(':');
             if (colonIndex > 0) {
                 var paramstring = newUrl.substring(colonIndex - 1, newUrl.length);
@@ -284,12 +286,9 @@
                         newUrl += '/' + data[params[i]];
                     }
                 }
+            }
 
-                sammy.setLocation(newUrl);
-            }
-            else {
-                sammy.setLocation(url);
-            }
+            sammy.setLocation(newUrl);
         },
         replaceLocation: function (url) {
             window.location.replace(url);


### PR DESCRIPTION
Added a navigateToRoute method to the router.
With this method it is possible to navigate to an url with parameters using an object for the parameters. This helps to avoid having the order of parameters in the url throughout the entire application.

As an example, if there is a route 'test/:id' you can navigate to it using router.navigateToRoute('test', { id: 2 });
Or with a route 'test/:id/:comment' you can navigate using router.navigateToRoute('test', { id: 2, comment: 'myComment' });
