### PR TITLE
Added onRouteComposed hook to router

### DIFF
--- a/App/durandal/plugins/router.js
+++ b/App/durandal/plugins/router.js
@@ -224,6 +224,7 @@
             setTimeout(function () {
                 isNavigating(false);
                 dequeueRoute();
+                router.onRouteComposed && router.onRouteComposed(router.activeRoute());
             }, 10);
         },
         getActivatableInstance: function (routeInfo, params, module) {


### PR DESCRIPTION
In certain scenarios you want to perform actions when a route not only has completed but when also the new view has been composed. This hook allows that.
