### PR TITLE
Added support for computed route captions

### DIFF
--- a/App/durandal/system.js
+++ b/App/durandal/system.js
@@ -122,6 +122,10 @@
         isArray: function(obj) {
             return toString.call(obj) === '[object Array]';
         },
+        isFunction: function(obj) {
+            var getType = {};
+            return obj && getType.toString.call(obj) === '[object Function]';
+        },
         log: noop,
         defer: function(action) {
             return $.Deferred(action);


### PR DESCRIPTION
Useful when view titles depend on state in your view models.

Usage: provide route name or caption in a function instead of a string.
