### PR TITLE
Hack to improve compatibility with TypeScript

### DIFF
--- a/App/durandal/composition.js
+++ b/App/durandal/composition.js
@@ -269,7 +269,10 @@
                 system.acquire(settings.model).then(function (module) {
                     if (typeof (module) == 'function') {
                         settings.model = new module(element, settings);
-                    } else {
+                    } else if (module.model && typeof (module.model) == 'function') {
+                        settings.model = new module.model(element, settings);
+                    }
+                    else {
                         settings.model = module;
                     }
 


### PR DESCRIPTION
I've added small hack to improve compatibility with TypeScript.

Currently TypeScript doesn't allow to yield results of AMD modules, but putting all result to exports variable. So it is a bit hard to implement widgets this way.

e.g. if you write this widget:

``` js
import widget = module('durandal/widget');

export class widgetA {
    connstructor(element, settings) {
    }

    public methodA() {
    }
}
```

It will compiles to:

``` js
define(["require", "exports"], function(require, exports) {

    var widgetA = (function () {
        function widgetA() { }
        widgetA.prototype.connstructor = function (element, settings) {
        };
        widgetA.prototype.methodA = function () {
        };
        return widgetA;
    })();
    exports.widgetA = widgetA;    
})
```

And will never works as a Widget.

But with this hack you should just add this lines:

``` js
declare var exports;
exports.model = widgetA;
```

which compiles to:

``` js
exports.widgetA = widgetA;    
exports.model = widgetA;
```

And now it works fine. I hope TypeScript team will fix this in next releases of compiler, but for now I have no another idea how to avoid this limitation and work best way with Durandal and TypeScript.
