### PR TITLE
FIX for nested widgets with data-parts

### DIFF
--- a/App/durandal/widget.js
+++ b/App/durandal/widget.js
@@ -24,7 +24,8 @@
                         parts[id] = element;
                     }
 
-                    var childParts = $(widgetPartSelector, element);
+                    var childParts = $(widgetPartSelector, element)
+                                        .not($('[data-bind^="widget:"] ' + widgetPartSelector, element)); 
 
                     for (var j = 0; j < childParts.length; j++) {
                         var part = childParts.get(j);


### PR DESCRIPTION
invoking a widget with data-part overrides within a data-part does not work.

example:
&lt;div data-bind="widget: outer">
&nbsp;&lt;div data-part="outer-widget-part">
&nbsp;&nbsp;&lt;div data-bind="widget: inner">
&nbsp;&nbsp;&nbsp;&lt;div data-part="inner-widget-part">
&nbsp;&nbsp;&nbsp;&nbsp;this will not take effect
&nbsp;&nbsp;&nbsp;&lt;/div>
&nbsp;&nbsp;&lt;/div>
&nbsp;&lt;/div>
&lt;/div>

reason: the outer widget consumes the data-part of the inner widget.

solution: ignore data-parts within widget bindings
