### PR TITLE
Fixed problem with optimizer not launching RequireJS

### DIFF
--- a/Optimizer/RJSRunner.cs
+++ b/Optimizer/RJSRunner.cs
@@ -49,17 +49,21 @@ namespace Optimizer {
           Arguments = command,
           UseShellExecute = false,
           CreateNoWindow = true,
-          RedirectStandardOutput = true
+          RedirectStandardOutput = true,
+          RedirectStandardError = true,
         },
         EnableRaisingEvents = true
       };
 
       process.OutputDataReceived += (s, e) => Console.WriteLine(e.Data);
+      process.ErrorDataReceived += (s, e) => Console.Error.WriteLine(e.Data);
 
       process.Start();
       process.BeginOutputReadLine();
+      process.BeginErrorReadLine();
       process.WaitForExit();
       process.CancelOutputRead();
+      process.CancelErrorRead();
     }
   }
 }


### PR DESCRIPTION
When running optimizer.exe from the command line, RequireJS wouldn't launch successfully after app.build.js was created.
