### PR TITLE
making "parseMarkupCore" overridable.

### DIFF
--- a/App/durandal/viewEngine.js
+++ b/App/durandal/viewEngine.js
@@ -1,12 +1,12 @@
 ﻿define(['./system'], function (system) {
-    var parseMarkupCore;
+    var parseMarkup;
 
     if ($.parseHTML) {
-        parseMarkupCore = function(html) {
+        parseMarkup = function (html) {
             return $.parseHTML(html);
         };
     } else {
-        parseMarkupCore = function(html) {
+        parseMarkup = function (html) {
             return $(html).get();
         };
     }
@@ -23,15 +23,15 @@
         convertViewIdToRequirePath: function (viewId) {
             return this.viewPlugin + '!' + viewId + this.viewExtension;
         },
-        parseMarkupCore: parseMarkupCore,
-        parseMarkup: function (markup) {
-            var allElements = this.parseMarkupCore(markup);
+        parseMarkup: parseMarkup,
+        processMarkup: function (markup) {
+            var allElements = viewEngine.parseMarkup(markup);
             if (allElements.length == 1) {
                 return allElements[0];
             }
 
             var withoutCommentsOrEmptyText = [];
-            
+
             for (var i = 0; i < allElements.length; i++) {
                 var current = allElements[i];
                 if (current.nodeType != 8) {
@@ -58,7 +58,7 @@
 
             return system.defer(function(dfd) {
                 system.acquire(requirePath).then(function(markup) {
-                    var element = that.parseMarkup(markup);
+                    var element = that.processMarkup(markup);
                     element.setAttribute('data-view', viewId);
                     dfd.resolve(element);
                 });

--- a/skeletons/nuget/Durandal.Router/content/App/durandal/viewEngine.js
+++ b/skeletons/nuget/Durandal.Router/content/App/durandal/viewEngine.js
@@ -1,17 +1,19 @@
 ﻿define(['./system'], function (system) {
-    var parseMarkupCore;
+    var viewEngine;
+    var parseMarkup;
 
     if ($.parseHTML) {
-        parseMarkupCore = function(html) {
+        parseMarkup = function (html) {
             return $.parseHTML(html);
         };
     } else {
-        parseMarkupCore = function(html) {
+        parseMarkup = function (html) {
             return $(html).get();
         };
     }
 
-    return {
+
+    return viewEngine = {
         viewExtension: '.html',
         viewPlugin: 'text',
         isViewUrl: function (url) {
@@ -23,15 +25,15 @@
         convertViewIdToRequirePath: function (viewId) {
             return this.viewPlugin + '!' + viewId + this.viewExtension;
         },
-        parseMarkupCore: parseMarkupCore,
-        parseMarkup: function (markup) {
-            var allElements = this.parseMarkupCore(markup);
+        parseMarkup: parseMarkup,
+        processMarkup: function (markup) {
+            var allElements = viewEngine.parseMarkup(markup);
             if (allElements.length == 1) {
                 return allElements[0];
             }
 
             var withoutCommentsOrEmptyText = [];
-            
+
             for (var i = 0; i < allElements.length; i++) {
                 var current = allElements[i];
                 if (current.nodeType != 8) {
@@ -58,7 +60,7 @@
 
             return system.defer(function(dfd) {
                 system.acquire(requirePath).then(function(markup) {
-                    var element = that.parseMarkup(markup);
+                    var element = that.processMarkup(markup);
                     element.setAttribute('data-view', viewId);
                     dfd.resolve(element);
                 });

--- a/skeletons/nuget/Durandal.Transitions/content/App/durandal/viewEngine.js
+++ b/skeletons/nuget/Durandal.Transitions/content/App/durandal/viewEngine.js
@@ -1,17 +1,19 @@
 ﻿define(['./system'], function (system) {
-    var parseMarkupCore;
+    var viewEngine;
+    var parseMarkup;
 
     if ($.parseHTML) {
-        parseMarkupCore = function(html) {
+        parseMarkup = function (html) {
             return $.parseHTML(html);
         };
     } else {
-        parseMarkupCore = function(html) {
+        parseMarkup = function (html) {
             return $(html).get();
         };
     }
 
-    return {
+
+    return viewEngine = {
         viewExtension: '.html',
         viewPlugin: 'text',
         isViewUrl: function (url) {
@@ -23,15 +25,15 @@
         convertViewIdToRequirePath: function (viewId) {
             return this.viewPlugin + '!' + viewId + this.viewExtension;
         },
-        parseMarkupCore: parseMarkupCore,
-        parseMarkup: function (markup) {
-            var allElements = this.parseMarkupCore(markup);
+        parseMarkup: parseMarkup,
+        processMarkup: function (markup) {
+            var allElements = viewEngine.parseMarkup(markup);
             if (allElements.length == 1) {
                 return allElements[0];
             }
 
             var withoutCommentsOrEmptyText = [];
-            
+
             for (var i = 0; i < allElements.length; i++) {
                 var current = allElements[i];
                 if (current.nodeType != 8) {
@@ -58,7 +60,7 @@
 
             return system.defer(function(dfd) {
                 system.acquire(requirePath).then(function(markup) {
-                    var element = that.parseMarkup(markup);
+                    var element = that.processMarkup(markup);
                     element.setAttribute('data-view', viewId);
                     dfd.resolve(element);
                 });

--- a/skeletons/nuget/Durandal/content/App/durandal/viewEngine.js
+++ b/skeletons/nuget/Durandal/content/App/durandal/viewEngine.js
@@ -1,17 +1,19 @@
 ﻿define(['./system'], function (system) {
-    var parseMarkupCore;
+    var viewEngine;
+    var parseMarkup;
 
     if ($.parseHTML) {
-        parseMarkupCore = function(html) {
+        parseMarkup = function (html) {
             return $.parseHTML(html);
         };
     } else {
-        parseMarkupCore = function(html) {
+        parseMarkup = function (html) {
             return $(html).get();
         };
     }
 
-    return {
+
+    return viewEngine = {
         viewExtension: '.html',
         viewPlugin: 'text',
         isViewUrl: function (url) {
@@ -23,15 +25,15 @@
         convertViewIdToRequirePath: function (viewId) {
             return this.viewPlugin + '!' + viewId + this.viewExtension;
         },
-        parseMarkupCore: parseMarkupCore,
-        parseMarkup: function (markup) {
-            var allElements = this.parseMarkupCore(markup);
+        parseMarkup: parseMarkup,
+        processMarkup: function (markup) {
+            var allElements = viewEngine.parseMarkup(markup);
             if (allElements.length == 1) {
                 return allElements[0];
             }
 
             var withoutCommentsOrEmptyText = [];
-            
+
             for (var i = 0; i < allElements.length; i++) {
                 var current = allElements[i];
                 if (current.nodeType != 8) {
@@ -58,7 +60,7 @@
 
             return system.defer(function(dfd) {
                 system.acquire(requirePath).then(function(markup) {
-                    var element = that.parseMarkup(markup);
+                    var element = that.processMarkup(markup);
                     element.setAttribute('data-view', viewId);
                     dfd.resolve(element);
                 });

--- a/skeletons/vstemplate/DurandalTemplate/DurandalTemplate/App/durandal/viewEngine.js
+++ b/skeletons/vstemplate/DurandalTemplate/DurandalTemplate/App/durandal/viewEngine.js
@@ -1,17 +1,19 @@
 ﻿define(['./system'], function (system) {
-    var parseMarkupCore;
+    var viewEngine;
+    var parseMarkup;
 
     if ($.parseHTML) {
-        parseMarkupCore = function(html) {
+        parseMarkup = function (html) {
             return $.parseHTML(html);
         };
     } else {
-        parseMarkupCore = function(html) {
+        parseMarkup = function (html) {
             return $(html).get();
         };
     }
 
-    return {
+
+    return viewEngine = {
         viewExtension: '.html',
         viewPlugin: 'text',
         isViewUrl: function (url) {
@@ -23,15 +25,15 @@
         convertViewIdToRequirePath: function (viewId) {
             return this.viewPlugin + '!' + viewId + this.viewExtension;
         },
-        parseMarkupCore: parseMarkupCore,
-        parseMarkup: function (markup) {
-            var allElements = this.parseMarkupCore(markup);
+        parseMarkup: parseMarkup,
+        processMarkup: function (markup) {
+            var allElements = viewEngine.parseMarkup(markup);
             if (allElements.length == 1) {
                 return allElements[0];
             }
 
             var withoutCommentsOrEmptyText = [];
-            
+
             for (var i = 0; i < allElements.length; i++) {
                 var current = allElements[i];
                 if (current.nodeType != 8) {
@@ -58,7 +60,7 @@
 
             return system.defer(function(dfd) {
                 system.acquire(requirePath).then(function(markup) {
-                    var element = that.parseMarkup(markup);
+                    var element = that.processMarkup(markup);
                     element.setAttribute('data-view', viewId);
                     dfd.resolve(element);
                 });

--- a/test/specs/viewEngine.spec.js
+++ b/test/specs/viewEngine.spec.js
@@ -30,10 +30,10 @@ define(['durandal/viewEngine', 'durandal/system'], function (sut, system) {
         });
     });
 
-    describe('parseMarkup', function () {
+    describe('processMarkup', function () {
         describe('with single node', function () {
             it('returns dom element', function () {
-                var markup = sut.parseMarkup('<div>test</div>');
+                var markup = sut.processMarkup('<div>test</div>');
 
                 expect(markup.nodeType).toBe(1);
                 expect(markup.innerText).toBe('test');
@@ -43,7 +43,7 @@ define(['durandal/viewEngine', 'durandal/system'], function (sut, system) {
 
         describe('with multiple nodes', function () {
             it('returns wrapped dom element', function () {
-                var markup = sut.parseMarkup('<div>test</div><div>test</div>');
+                var markup = sut.processMarkup('<div>test</div><div>test</div>');
 
                 expect(markup.className).toBe('durandal-wrapper');
                 expect(markup.childNodes.length).toBe(2);
@@ -52,7 +52,7 @@ define(['durandal/viewEngine', 'durandal/system'], function (sut, system) {
 
         describe('with comments', function () {
             it('returns dom element with comments removed', function () {
-                var markup = sut.parseMarkup('<!-- this is a comment --><div>test</div>');
+                var markup = sut.processMarkup('<!-- this is a comment --><div>test</div>');
 
                 expect(markup.nodeType).toBe(1);
                 expect(markup.innerText).toBe('test');
@@ -61,25 +61,34 @@ define(['durandal/viewEngine', 'durandal/system'], function (sut, system) {
         });
     });
 
-    describe('parseMarkup with alternate parseMarkupCore', function () {
+    describe('processMarkup with alternate parseMarkup', function () {
 
-        var oldParseMarkupCore = null;
+        var oldParseMarkup = null;
+        var spyable = null;
 
         beforeEach(function () {
-            oldParseMarkupCore = sut.parseMarkupCore;
-            sut.parseMarkupCore = function parseIt(markup) {
-                return $.parseHtml(markup);
-            }
+            spyable = {
+                parseIt: function (markup) {
+                    return $.parseHTML(markup);
+                }
+            };
+
+            oldParseMarkup = sut.parseMarkup;
+            var spied = spyOn(spyable, 'parseIt').andCallThrough();
+            sut.parseMarkup = spied;
         });
 
         afterEach(function () {
-            sut.parseMarkupCore = oldParseMarkupCore;
+            sut.parseMarkup = oldParseMarkup;
+            oldParseMarkup = null;
+            spyable = null;
         });
 
         describe('with single node', function () {
             it('returns dom element', function () {
-                var markup = sut.parseMarkup('<div>test</div>');
+                var markup = sut.processMarkup('<div>test</div>');
 
+                expect(spyable.parseIt).toHaveBeenCalled();
                 expect(markup.nodeType).toBe(1);
                 expect(markup.innerText).toBe('test');
                 expect(markup.childNodes[0].nodeType).toBe(3);
@@ -88,8 +97,9 @@ define(['durandal/viewEngine', 'durandal/system'], function (sut, system) {
 
         describe('with multiple nodes', function () {
             it('returns wrapped dom element', function () {
-                var markup = sut.parseMarkup('<div>test</div><div>test</div>');
+                var markup = sut.processMarkup('<div>test</div><div>test</div>');
 
+                expect(spyable.parseIt).toHaveBeenCalled();
                 expect(markup.className).toBe('durandal-wrapper');
                 expect(markup.childNodes.length).toBe(2);
             });
@@ -97,8 +107,9 @@ define(['durandal/viewEngine', 'durandal/system'], function (sut, system) {
 
         describe('with comments', function () {
             it('returns dom element with comments removed', function () {
-                var markup = sut.parseMarkup('<!-- this is a comment --><div>test</div>');
+                var markup = sut.processMarkup('<!-- this is a comment --><div>test</div>');
 
+                expect(spyable.parseIt).toHaveBeenCalled();
                 expect(markup.nodeType).toBe(1);
                 expect(markup.innerText).toBe('test');
                 expect(markup.childNodes[0].nodeType).toBe(3);


### PR DESCRIPTION
exposed "parseMarkupCore" on the View Engine so that overriding this can still take advantage of the other code in the "parseMarkup" method that strips comments and whitespace and ensures a single return element.
