### PR TITLE
Hierarchical Router

### DIFF
--- a/App/durandal/plugins/history.js
+++ b/App/durandal/plugins/history.js
@@ -30,7 +30,6 @@
     };
 
     var history = {
-        handlers: [],
         interval: 50,
         active: false
     };
@@ -139,12 +138,6 @@
         history.active = false;
     };
     
-    // Add a route to be tested when the fragment changes. Routes added later
-    // may override previous routes.
-    history.route = function(route, callback) {
-        history.handlers.unshift({ route: route, callback: callback });
-    };
-    
     // Checks the current URL to see if it has changed, and if it has,
     // calls `loadUrl`, normalizing across the hidden iframe.
     history.checkUrl = function(e) {
@@ -164,22 +157,13 @@
         history.loadUrl() || history.loadUrl(history.getHash());
     };
     
-    // Attempt to load the current URL fragment. If a route succeeds with a
-    // match, returns `true`. If no defined routes matches the fragment,
-    // returns `false`.
+    // Attempt to load the current URL fragment. pass it to options.routeHandler
     history.loadUrl = function(fragmentOverride) {
         var fragment = history.fragment = history.getFragment(fragmentOverride);
-        var handlers = history.handlers;
 
-        for (var i = 0; i < handlers.length; i++) {
-            var current = handlers[i];
-            if (current.route.test(fragment)) {
-                current.callback(fragment);
-                return true;
-            }
-        }
-
-        return false;
+        return history.options.routeHandler ?
+            history.options.routeHandler(fragment) :
+            false;
     };
     
     // Save a fragment into the hash history, or replace the URL state if the

--- a/App/samples/knockout/index.html
+++ b/App/samples/knockout/index.html
@@ -5,20 +5,28 @@
             <li class="nav-header">Basic Examples</li>
             
             <!--ko foreach: introSamples-->
-            <li data-bind="css: {active:$parent.activeSample().__moduleId__ == $data.moduleId}">
-                <a data-bind="attr: { href: hash }, text: name"></a>
+            <li data-bind="css: { active: isActive }">
+                <a data-bind="attr: { href: hash }, text: title"></a>
             </li>
             <!--/ko-->
 
             <li class="nav-header">Detailed Examples</li>
             
+
             <!--ko foreach: detailedSamples-->
-            <li data-bind="css: { active: $parent.activeSample().__moduleId__ == $data.moduleId }">
-                <a data-bind="attr: { href: hash }, text: name"></a>
+            <li data-bind="css: { active: isActive }">
+                <a data-bind="attr: { href: hash }, text: title"></a>
             </li>
             <!--/ko-->
         </ul>
     </div>
-    <div class="span10" data-bind="compose: activeSample"></div>
+      <div class="span10">
+            <!--ko compose: { 
+                model: router.activeItem, //wiring the router
+                afterCompose: router.afterCompose, //wiring the router
+                transition:'entrance', //use the 'entrance' transition when switching views
+                cacheViews:true //telling composition to keep views in the dom, and reuse them (only a good idea with singleton view models)
+            }--><!--/ko-->
+      </div>
   </div>
 </div>

--- a/App/samples/knockout/index.js
+++ b/App/samples/knockout/index.js
@@ -1,66 +1,96 @@
 ﻿define(function () {
-    var system = require('durandal/system'),
-        viewModel = require('durandal/viewModel');
-    
-    return {
-        activeSample:viewModel.activator(),
-        introSamples: [{
-            name: 'Hello World',
-            hash: '#knockout-samples/helloWorld',
-            moduleId: 'samples/knockout/helloWorld/index'
-        },{
-            name: 'Click Counter',
-            hash: '#knockout-samples/clickCounter',
-            moduleId: 'samples/knockout/clickCounter/index'
-        },{
-            name: 'Simple List',
-            hash: '#knockout-samples/simpleList',
-            moduleId: 'samples/knockout/simpleList/index'
-        },{
-            name: 'Better List',
-            hash: '#knockout-samples/betterList',
-            moduleId: 'samples/knockout/betterList/index'
-        },{
-            name: 'Control Types',
-            hash: '#knockout-samples/controlTypes',
-            moduleId: 'samples/knockout/controlTypes/index'
-        },{
-            name: 'Collection',
-            hash: '#knockout-samples/collections',
-            moduleId: 'samples/knockout/collections/index'
-        },{
-            name: 'Paged Grid',
-            hash: '#knockout-samples/pagedGrid',
-            moduleId: 'samples/knockout/pagedGrid/index'
-        },{
-            name: 'Animated Transition',
-            hash: '#knockout-samples/animatedTrans',
-            moduleId: 'samples/knockout/animatedTrans/index'
-        }],
-        detailedSamples: [{
-            name: 'Contacts Editor',
-            hash: '#knockout-samples/contactsEditor',
-            moduleId: 'samples/knockout/contactsEditor/index'
-        },{
-            name: 'Grid Editor',
-            hash: '#knockout-samples/gridEditor',
-            moduleId: 'samples/knockout/gridEditor/index'
-        },{
-            name: 'Shopping Cart',
-            hash: '#knockout-samples/shoppingCart',
-            moduleId: 'samples/knockout/shoppingCart/index'
-        },{
-            name: 'Twitter Client',
-            hash: '#knockout-samples/twitterClient',
-            moduleId: 'samples/knockout/twitterClient/index'
-        }],
-        activate: function (name) {
-            var that = this;
-            name = name || 'helloWorld';
+    var router = require('durandal/plugins/router');
 
-            return system.acquire('samples/knockout/' + name + '/index').then(function(sample) {
-                that.activeSample(sample);
+    var childRouter = router.create();
+    childRouter.map([{
+        type: 'intro',
+        route: 'knockout-samples/helloWorld',
+        moduleId: 'samples/knockout/helloWorld/index',
+        title: 'Hello World',
+        nav: true
+    }, {
+        type: 'intro',
+        route: 'knockout-samples/clickCounter',
+        moduleId: 'samples/knockout/clickCounter/index',
+        title: 'Click Counter',
+        nav: true
+    }, {
+        type: 'intro',
+        route: 'knockout-samples/simpleList',
+        moduleId: 'samples/knockout/simpleList/index',
+        title: 'Simple List',
+        nav: true
+    }, {
+        type: 'intro',
+        route: 'knockout-samples/betterList',
+        moduleId: 'samples/knockout/betterList/index',
+        title: 'Better List',
+        nav: true
+    }, {
+        type: 'intro',
+        route: 'knockout-samples/controlTypes',
+        moduleId: 'samples/knockout/controlTypes/index',
+        title: 'Control Types',
+        nav: true
+    }, {
+        type: 'intro',
+        route: 'knockout-samples/collections',
+        moduleId: 'samples/knockout/collections/index',
+        title: 'Collection',
+        nav: true
+    }, {
+        type: 'intro',
+        route: 'knockout-samples/pagedGrid',
+        moduleId: 'samples/knockout/pagedGrid/index',
+        title: 'Paged Grid',
+        nav: true
+    }, {
+        type: 'intro',
+        route: 'knockout-samples/animatedTrans',
+        moduleId: 'samples/knockout/animatedTrans/index',
+        title: 'Animated Transition',
+        nav: true
+    }, {
+        type: 'detailed',
+        route: 'knockout-samples/contactsEditor',
+        moduleId: 'samples/knockout/contactsEditor/index',
+        title: 'Contacts Editor',
+        nav: true
+    }, {
+        type: 'detailed',
+        route: 'knockout-samples/gridEditor',
+        moduleId: 'samples/knockout/gridEditor/index',
+        title: 'Grid Editor',
+        nav: true
+    }, {
+        type: 'detailed',
+        route: 'knockout-samples/shoppingCart',
+        moduleId: 'samples/knockout/shoppingCart/index',
+        title: 'Shopping Cart',
+        nav: true
+    }, {
+        type: 'detailed',
+        route: 'knockout-samples/twitterClient',
+        moduleId: 'samples/knockout/twitterClient/index',
+        title: 'Twitter Client',
+        nav: true
+    }
+    ]).buildNavigationModel();
+
+
+    return {
+        router: childRouter,
+        introSamples: ko.computed(function () {
+            return ko.utils.arrayFilter(childRouter.navigationModel(), function (route) {
+                return route.type == 'intro';
             });
+        }),
+        detailedSamples: ko.computed(function () {
+            return ko.utils.arrayFilter(childRouter.navigationModel(), function (route) {
+                return route.type == 'detailed';
+            });
+        }),
+        activate: function () {
         },
         canReuseForRoute: function () {
             return true;

--- a/skeletons/nuget/Durandal.Router/content/App/durandal/plugins/history.js
+++ b/skeletons/nuget/Durandal.Router/content/App/durandal/plugins/history.js
@@ -30,7 +30,6 @@
     };
 
     var history = {
-        handlers: [],
         interval: 50,
         active: false
     };
@@ -139,12 +138,6 @@
         history.active = false;
     };
     
-    // Add a route to be tested when the fragment changes. Routes added later
-    // may override previous routes.
-    history.route = function(route, callback) {
-        history.handlers.unshift({ route: route, callback: callback });
-    };
-    
     // Checks the current URL to see if it has changed, and if it has,
     // calls `loadUrl`, normalizing across the hidden iframe.
     history.checkUrl = function(e) {
@@ -164,22 +157,13 @@
         history.loadUrl() || history.loadUrl(history.getHash());
     };
     
-    // Attempt to load the current URL fragment. If a route succeeds with a
-    // match, returns `true`. If no defined routes matches the fragment,
-    // returns `false`.
+    // Attempt to load the current URL fragment. pass it to options.routeHandler
     history.loadUrl = function(fragmentOverride) {
         var fragment = history.fragment = history.getFragment(fragmentOverride);
-        var handlers = history.handlers;
 
-        for (var i = 0; i < handlers.length; i++) {
-            var current = handlers[i];
-            if (current.route.test(fragment)) {
-                current.callback(fragment);
-                return true;
-            }
-        }
-
-        return false;
+        return history.options.routeHandler ?
+            history.options.routeHandler(fragment) :
+            false;
     };
     
     // Save a fragment into the hash history, or replace the URL state if the

--- a/skeletons/nuget/Durandal.Transitions/content/App/durandal/plugins/history.js
+++ b/skeletons/nuget/Durandal.Transitions/content/App/durandal/plugins/history.js
@@ -30,7 +30,6 @@
     };
 
     var history = {
-        handlers: [],
         interval: 50,
         active: false
     };
@@ -139,12 +138,6 @@
         history.active = false;
     };
     
-    // Add a route to be tested when the fragment changes. Routes added later
-    // may override previous routes.
-    history.route = function(route, callback) {
-        history.handlers.unshift({ route: route, callback: callback });
-    };
-    
     // Checks the current URL to see if it has changed, and if it has,
     // calls `loadUrl`, normalizing across the hidden iframe.
     history.checkUrl = function(e) {
@@ -164,22 +157,13 @@
         history.loadUrl() || history.loadUrl(history.getHash());
     };
     
-    // Attempt to load the current URL fragment. If a route succeeds with a
-    // match, returns `true`. If no defined routes matches the fragment,
-    // returns `false`.
+    // Attempt to load the current URL fragment. pass it to options.routeHandler
     history.loadUrl = function(fragmentOverride) {
         var fragment = history.fragment = history.getFragment(fragmentOverride);
-        var handlers = history.handlers;
 
-        for (var i = 0; i < handlers.length; i++) {
-            var current = handlers[i];
-            if (current.route.test(fragment)) {
-                current.callback(fragment);
-                return true;
-            }
-        }
-
-        return false;
+        return history.options.routeHandler ?
+            history.options.routeHandler(fragment) :
+            false;
     };
     
     // Save a fragment into the hash history, or replace the URL state if the

--- a/skeletons/nuget/Durandal/content/App/durandal/plugins/history.js
+++ b/skeletons/nuget/Durandal/content/App/durandal/plugins/history.js
@@ -30,7 +30,6 @@
     };
 
     var history = {
-        handlers: [],
         interval: 50,
         active: false
     };
@@ -139,12 +138,6 @@
         history.active = false;
     };
     
-    // Add a route to be tested when the fragment changes. Routes added later
-    // may override previous routes.
-    history.route = function(route, callback) {
-        history.handlers.unshift({ route: route, callback: callback });
-    };
-    
     // Checks the current URL to see if it has changed, and if it has,
     // calls `loadUrl`, normalizing across the hidden iframe.
     history.checkUrl = function(e) {
@@ -164,22 +157,13 @@
         history.loadUrl() || history.loadUrl(history.getHash());
     };
     
-    // Attempt to load the current URL fragment. If a route succeeds with a
-    // match, returns `true`. If no defined routes matches the fragment,
-    // returns `false`.
+    // Attempt to load the current URL fragment. pass it to options.routeHandler
     history.loadUrl = function(fragmentOverride) {
         var fragment = history.fragment = history.getFragment(fragmentOverride);
-        var handlers = history.handlers;
 
-        for (var i = 0; i < handlers.length; i++) {
-            var current = handlers[i];
-            if (current.route.test(fragment)) {
-                current.callback(fragment);
-                return true;
-            }
-        }
-
-        return false;
+        return history.options.routeHandler ?
+            history.options.routeHandler(fragment) :
+            false;
     };
     
     // Save a fragment into the hash history, or replace the URL state if the

--- a/skeletons/vstemplate/DurandalTemplate/DurandalTemplate/App/durandal/plugins/history.js
+++ b/skeletons/vstemplate/DurandalTemplate/DurandalTemplate/App/durandal/plugins/history.js
@@ -30,7 +30,6 @@
     };
 
     var history = {
-        handlers: [],
         interval: 50,
         active: false
     };
@@ -139,12 +138,6 @@
         history.active = false;
     };
     
-    // Add a route to be tested when the fragment changes. Routes added later
-    // may override previous routes.
-    history.route = function(route, callback) {
-        history.handlers.unshift({ route: route, callback: callback });
-    };
-    
     // Checks the current URL to see if it has changed, and if it has,
     // calls `loadUrl`, normalizing across the hidden iframe.
     history.checkUrl = function(e) {
@@ -164,22 +157,13 @@
         history.loadUrl() || history.loadUrl(history.getHash());
     };
     
-    // Attempt to load the current URL fragment. If a route succeeds with a
-    // match, returns `true`. If no defined routes matches the fragment,
-    // returns `false`.
+    // Attempt to load the current URL fragment. pass it to options.routeHandler
     history.loadUrl = function(fragmentOverride) {
         var fragment = history.fragment = history.getFragment(fragmentOverride);
-        var handlers = history.handlers;
 
-        for (var i = 0; i < handlers.length; i++) {
-            var current = handlers[i];
-            if (current.route.test(fragment)) {
-                current.callback(fragment);
-                return true;
-            }
-        }
-
-        return false;
+        return history.options.routeHandler ?
+            history.options.routeHandler(fragment) :
+            false;
     };
     
     // Save a fragment into the hash history, or replace the URL state if the


### PR DESCRIPTION
having a hierarchical router is very useful in cases where we have
sub-shells with dedicated menus, like knockout sample itself. the sample
is not such that complex to feel the need for such a router, but in more advanced
scenarios it's really helpful.

i have moved loadUrl logic from history to router. now sole
responsibility of history is to tell whenever the url changes. router
itself must handle urls. now we can have different routers. there's a
default router like before, but a create method is provided for
creations of child routers.
history tells url changes only to default (root) router, each router
notifies it's children if there's any.
