### PR TITLE
Routes with equal viewModel are problematic

### DIFF
--- a/App/durandal/viewModel.js
+++ b/App/durandal/viewModel.js
@@ -223,7 +223,7 @@
                 var currentItem = activeItem();
                 if (settings.areSameItem(currentItem, newItem, activationData)) {
                     computed.isActivating(false);
-                    dfd.resolve(true);
+                    dfd.resolve(false);
                     return;
                 }
 


### PR DESCRIPTION
whenever there are different routes resolving to the same viewmodel, if one of them is active and user tries to activate the other one, router stucks in isNavigatiing state equal to true.
after that no more route changes works.

i believe in viewModel.js module, in computed.activateItem function, whenever settings.areSameItem is true, it must resolve to false (and not true).

this way navigations gets canceled and router.isNavigating changes back to false.
