### PR TITLE
Adding navigatedTo and NavigatedFrom triggers to the router - completeNavigation

### DIFF
--- a/App/durandal/plugins/router.js
+++ b/App/durandal/plugins/router.js
@@ -51,8 +51,16 @@ function(system, app, viewModel, events, history) {
         function completeNavigation(instance, instruction) {
             system.log('Navigation Complete', instance, instruction);
 
+            if (currentActivation && currentActivation.__moduleId__) {
+                router.trigger('router:navigatedFrom:' + currentActivation.__moduleId__);
+            }
+
             currentActivation = instance;
             currentInstruction = instruction;
+
+            if (currentActivation && currentActivation.__moduleId__) {
+                router.trigger('router:navigatedTo:' + currentActivation.__moduleId__);
+            }
 
             if (!hasChildRouter(instance)) {
                 router.updateDocumentTitle(instance, instruction);


### PR DESCRIPTION
Adding navigatedTo and NavigatedFrom triggers to the router.js - completeNavigation function.  The third parameter in the trigger key is the moduleId of the active route.  

The route is mapped as:

router.map([
    { route: '', moduleId: 'viewmodels/myViewModel', title: 'My View', nav: true }
]).buildNavigationModel();

The triggers can be subscribed to:

router.on('router:navigatedTo:viewmodels/myViewModel', function () {
     alert('Navigated to myViewModel.')
});

router.on('router:navigatedFrom:viewmodels/myViewModel', function () {
     alert('Navigated from myViewModel.')
});
