### PR TITLE
childRouter.parent is ambiguous

### DIFF
--- a/App/durandal/plugins/router.js
+++ b/App/durandal/plugins/router.js
@@ -440,7 +440,6 @@ function(system, app, viewModel, events, history) {
 
         router.createChildRouter = function() {
             var childRouter = createRouter();
-            childRouter.parent = router;
             return childRouter;
         };
 


### PR DESCRIPTION
The easiest possible way to create a child router is through the root one (singleton), so the childRouter.parent will become that router. This is no problem when child router is in depth 2, but for depth 3 the parent will become root router which is wrong.

There is two solutions:
- Have a createRouter hooking function in viewModel and pass it parent router, so that this viewModel can create it's router through that parent one. This solution is really complex and not good.
- Ostrich Solution: Don't provide the parent router in child routers. I believe not providing something is better than a ambiguous one.
