### PR TITLE
Delete obsolete link to twitterExample.css

### DIFF
--- a/platforms/HTML/Samples/app/knockout/twitterClient/index.html
+++ b/platforms/HTML/Samples/app/knockout/twitterClient/index.html
@@ -1,5 +1,3 @@
-﻿<!-- NOTE: KnockoutJS Live Examples adds CSS same way as here -->
-<link href='Content/twitterExample.css' rel='Stylesheet' />
 <div>
     <h2>Twitter Client</h2>
     <div class='configuration'>


### PR DESCRIPTION
These styles were migrated to samples.css.
