### PR TITLE
Ignore all falsey values for nav

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -380,7 +380,7 @@ function(system, app, activator, events, history) {
             for (var i = 0; i < routes.length; i++) {
                 var current = routes[i];
 
-                if (current.nav != undefined) {
+                if (current.nav) {
                     if (!system.isNumber(current.nav)) {
                         current.nav = defaultOrder;
                     }


### PR DESCRIPTION
Made the check for navigable routes a little more robust by ignoring all falsey values, rather than simply `undefined`.
