### PR TITLE
/src/build.ps1 ... destination folders not being recursively build.  

### DIFF
--- a/src/build.ps1
+++ b/src/build.ps1
@@ -1,5 +1,7 @@
 $srcDir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 $distDir = [IO.Path]::GetFullPath( (join-path $srcDir "../dist") )
+Remove-Item $distDir -Force -Recurse
+
 $startFragment = $srcDir + "/start.jsfrag"
 
 function buildDurandal(){


### PR DESCRIPTION
Build failed on my clean machine because destination folders were not being recursively built.  I'm new to powershell so I just added for a few directory create commands and used xcopy for hierarchies of unknown depth.  Build works.

http://blog.netnerds.net/2011/10/powershell-copy-item-recurse-force-does-not-create-directories-when-using-get-childitem-include/
http://stackoverflow.com/questions/5432290/how-to-use-powershell-copy-item-and-keep-structure
