### PR TITLE
Remove unnecessary shims for jQuery and Knockout

### DIFF
--- a/platforms/HTML/Samples/app/main.js
+++ b/platforms/HTML/Samples/app/main.js
@@ -9,12 +9,6 @@
         'jquery': '../lib/jquery/jquery-1.9.1'
     },
     shim: {
-        'knockout': {
-            exports: 'ko'
-        },
-        'jquery': {
-            exports: '$'
-        },
         'bootstrap': {
             deps: ['jquery'],
             exports: '$.support.transition' // just picked one

--- a/platforms/HTML/StarterKit/app/main.js
+++ b/platforms/HTML/StarterKit/app/main.js
@@ -9,12 +9,6 @@
         'jquery': '../lib/jquery/jquery-1.9.1'
     },
     shim: {
-        'knockout': {
-            exports: 'ko'
-        },
-        'jquery': {
-            exports: '$'
-        },
         'bootstrap': {
             deps: ['jquery'],
             exports: '$.support.transition' // just picked one

--- a/platforms/Microsoft.NET/Nuget/Durandal.StarterKit/content/App/main.js
+++ b/platforms/Microsoft.NET/Nuget/Durandal.StarterKit/content/App/main.js
@@ -9,12 +9,6 @@
         'jquery': '../Scripts/jquery-1.9.1'
     },
     shim: {
-        'knockout': {
-            exports: 'ko'
-        },
-        'jquery': {
-            exports: '$'
-        },
         'bootstrap': {
             deps: ['jquery'],
             exports: '$.support.transition' // just picked one

--- a/platforms/Microsoft.NET/Samples/Durandal.Samples/App/main.js
+++ b/platforms/Microsoft.NET/Samples/Durandal.Samples/App/main.js
@@ -9,12 +9,6 @@
         'jquery': '../Scripts/jquery-1.9.1'
     },
     shim: {
-        'knockout': {
-            exports: 'ko'
-        },
-        'jquery': {
-            exports: '$'
-        },
         'bootstrap': {
             deps: ['jquery'],
             exports: '$.support.transition' // just picked one

--- a/platforms/Microsoft.NET/StarterKit/nuget/Durandal.StarterKit/content/App/main.js
+++ b/platforms/Microsoft.NET/StarterKit/nuget/Durandal.StarterKit/content/App/main.js
@@ -9,12 +9,6 @@
         'jquery': '../Scripts/jquery-1.9.1'
     },
     shim: {
-        'knockout': {
-            exports: 'ko'
-        },
-        'jquery': {
-            exports: '$'
-        },
         'bootstrap': {
             deps: ['jquery'],
             exports: '$.support.transition' // just picked one

--- a/test/spec.html
+++ b/test/spec.html
@@ -17,14 +17,6 @@
                 'transitions' : 'transitions/js',
                 'knockout': '../lib/knockout/knockout-2.2.1',
                 'jquery': '../lib/jquery/jquery-1.9.1'
-            },
-            shim: {
-                'knockout': {
-                    exports: 'ko'
-                },
-                'jquery': {
-                    exports: '$'
-                }
             }
         });
         var runTests = function (specfiles) {


### PR DESCRIPTION
Since jQuery and Knockout both support AMD, shims for them are not necessary. In fact, RequireJS will detect that they are loaded as AMD modules and ignore the shim configuration.
