### PR TITLE
Patch addBindingHandler to clone properties of config object

### DIFF
--- a/platforms/HTML/Samples/lib/durandal/js/composition.js
+++ b/platforms/HTML/Samples/lib/durandal/js/composition.js
@@ -170,7 +170,9 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/viewModelBinder', '
             }
         },
         addBindingHandler:function(name, config){
-            var dataKey = 'composition-handler-' + name;
+            var key,
+                value,
+                dataKey = 'composition-handler-' + name;
 
             ko.bindingHandlers[name] = {
                 init: function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
@@ -203,6 +205,13 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/viewModelBinder', '
                     }
                 }
             };
+
+            for (key in config) {
+              value = config[key];
+              if (key !== "init" && key !== "update") {
+                ko.bindingHandlers[name][key] = value;
+              }
+            }
         },
         getParts: function(elements) {
             var parts = {};


### PR DESCRIPTION
This is my attempt at the patch discussed in #200 to the new `composition.addBindingHandler` method.  It clones properties from `config` other than `init` and `update` so that any helper functions or objects are available to the binding handler under its own namespace.
