### PR TITLE
Modify isNavigating that is always looking at child router's isNavigatin...

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -45,7 +45,12 @@
             activeItem: activeItem,
             isNavigating: ko.computed(function() {
                 var current = activeItem();
-                return isProcessing() || (current && current.router && current.router.isNavigating());
+                var processing = isProcessing();
+                	var currentRouterIsProcesing = current
+						&& current.router
+						&& current.router != router
+						&& current.router.isNavigating() ? true : false;
+            	return  processing || currentRouterIsProcesing;
             }),
             __router__:true
         };


### PR DESCRIPTION
...g property

This would fix cases where main router did not report that only the child router isNavigating
