### PR TITLE
added history.back method

### DIFF
--- a/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/plugins/history.js
+++ b/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/plugins/history.js
@@ -271,6 +271,14 @@ define(['durandal/system', 'jquery'], function (system, $) {
     };
 
     /**
+     * Navigate back one page, if possible
+     * @method back
+     */
+    history.back = function () {
+        history.history.back();
+    }
+
+    /**
      * @class HistoryOptions
      * @static
      */

--- a/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/plugins/router.js
+++ b/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/plugins/router.js
@@ -522,7 +522,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
          * @method navigateBack
          */
         router.navigateBack = function() {
-            history.history.back();
+            history.back();
         };
 
         router.attached = function() {


### PR DESCRIPTION
Added this so that the router is not directly relying on the
window.history object

related to: https://github.com/BlueSpire/Durandal/issues/231
