### PR TITLE
Don't try to navigate to a route when clicking an 'a' tag that starts with a hash (with pushState enabled)

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -783,7 +783,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                         // Ensure the protocol is not part of URL, meaning its relative.
                         // Stop the event bubbling to ensure the link will not cause a page refresh.
-                        if (href.slice(protocol.length) !== protocol) {
+                        if (href.chatAt(0) !== "#" && href.slice(protocol.length) !== protocol) {
                             evt.preventDefault();
                             history.navigate(href, true);
                         }


### PR DESCRIPTION
When clicking a link that has an href starting with "#", the router should not try to navigate to that route if you are using pushState. I added a check to make sure the first character isn't a hash.
