### PR TITLE
Fix in Router: Absolute links not working when using push state

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -879,7 +879,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                         // Ensure the protocol is not part of URL, meaning its relative.
                         // Stop the event bubbling to ensure the link will not cause a page refresh.
-                        if (!href || !/^[a-z]+:\/\//i.test(href)) {
+                        if (!href || !/^[a-z]+:/i.test(href)) {
                             evt.preventDefault();
                             history.navigate(href);
                         }


### PR DESCRIPTION
I tried the push state functionality of the router plugin, and it worked out quite well. There was one little issue where I couldn't navigate to external links due to a bug in the anchor event handler.

This fix uses a regex to check if the href starts with a protocol, as the following answer suggests: http://stackoverflow.com/a/10687137
