### PR TITLE
Fix in History.js: Fragment doesn't include query when using push state

### DIFF
--- a/src/plugins/js/history.js
+++ b/src/plugins/js/history.js
@@ -74,7 +74,7 @@ define(['durandal/system', 'jquery'], function (system, $) {
     history.getFragment = function(fragment, forcePushState) {
         if (fragment == null) {
             if (history._hasPushState || !history._wantsHashChange || forcePushState) {
-                fragment = history.location.pathname;
+                fragment = history.location.pathname + history.location.search;
                 var root = history.root.replace(trailingSlash, '');
                 if (!fragment.indexOf(root)) {
                     fragment = fragment.substr(root.length);


### PR DESCRIPTION
When using push state, query string parsing doesn't work and params are not passed to the activation callback. This fix adds `history.location.search` to the fragment.
