### PR TITLE
Update composition.js

### DIFF
--- a/src/durandal/js/composition.js
+++ b/src/durandal/js/composition.js
@@ -344,7 +344,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
                             }
                         }else if(context.activeView){
                             var instruction = binder.getBindingInstruction(context.activeView);
-                            if(instruction.cacheViews != undefined && !instruction.cacheViews){
+                            if(instruction != undefined && !instruction.cacheViews){
                                 ko.removeNode(context.activeView);
                             }
                         }


### PR DESCRIPTION
Undefined reference error when trying to remove the previous view binding instruction from the dom, which doesn't exist.
