### PR TITLE
Add "as" parameter to compose binding.

### DIFF
--- a/src/durandal/js/binder.js
+++ b/src/durandal/js/binder.js
@@ -125,10 +125,11 @@ define(['durandal/system', 'knockout'], function (system, ko) {
          * @param {KnockoutBindingContext} bindingContext The current binding context.
          * @param {DOMElement} view The view to bind.
          * @param {object} [obj] The data to bind to, causing the creation of a child binding context if present.
+         * @param {string} [dataAlias] An alias for $data if present.
          */
-        bindContext: function(bindingContext, view, obj) {
+        bindContext: function(bindingContext, view, obj, dataAlias) {
             if (obj && bindingContext) {
-                bindingContext = bindingContext.createChildContext(obj);
+                bindingContext = bindingContext.createChildContext(obj, typeof(dataAlias) === 'string' ? dataAlias : null);
             }
 
             return doBind(obj, view, bindingContext, obj || (bindingContext ? bindingContext.$data : null));

--- a/src/durandal/js/composition.js
+++ b/src/durandal/js/composition.js
@@ -404,7 +404,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
                         $(child).hide();
                         ko.virtualElements.prepend(context.parent, child);
 
-                        binder.bindContext(context.bindingContext, child, context.model);
+                        binder.bindContext(context.bindingContext, child, context.model, context.as);
                     }
                 } else if (child) {
                     var modelToBind = context.model || dummyModel;


### PR DESCRIPTION
This behaves like the "as" in Knockout's foreach.  This should be backwards compatible except in the unlikely case that someone was using an "as" property on their settings object, which was a string, which happens to match a property on their view model.  I can check in some changes to the viewComposition sample to demonstrate it if desired.
