### PR TITLE
Fixed close declaration for dialog plugin

### DIFF
--- a/src/typescript/durandal/durandal.d.ts
+++ b/src/typescript/durandal/durandal.d.ts
@@ -958,9 +958,9 @@ declare module 'plugins/dialog' {
     /**
      * Closes the dialog associated with the specified object.
      * @param {object} obj The object whose dialog should be closed.
-     * @param {object} result* The results to return back to the dialog caller after closing.
+     * @param {object} results* The results to return back to the dialog caller after closing.
     */
-    export function close(obj: any): void;
+    export function close(obj: any, ...results: any[]): void;
 
     /**
      * Shows a dialog.


### PR DESCRIPTION
The close declaration in Durandal's TypeScript d.ts file would not allow
for passing result parameters. Fixed by adding a rest argument called
results.
