### PR TITLE
Fixed Route Not Found error in IE11 Preview

### DIFF
--- a/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/plugins/router.js
+++ b/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/plugins/router.js
@@ -509,7 +509,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
                 var instruction = this.parent.activeInstruction();
                 coreFragment = instruction.params.join('/');
 
-                if(coreFragment && coreFragment[0] == '/'){
+                if(coreFragment && coreFragment.charAt(0) == '/'){
                     coreFragment = coreFragment.substr(1);
                 }
 

--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -504,7 +504,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
                 var instruction = this.parent.activeInstruction();
                 coreFragment = instruction.params.join('/');
 
-                if(coreFragment && coreFragment[0] == '/'){
+                if(coreFragment && coreFragment.charAt(0) == '/'){
                     coreFragment = coreFragment.substr(1);
                 }
 


### PR DESCRIPTION
IE11 Preview doesn't seem to implement Array-like character access as
spec'd out in ES5. This causes the Router to fail and log a _'Route Not
Found'_ error message. Strangely IE10 works ok, so I suspect this is a
regression in IE11 Preview. Changing the router to use `charAt(0)` instead of
`[0]` fixes this issue.
