### PR TITLE
Adding the ability to use a .hasSubRoutes boolean route property rather than *details

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -390,6 +390,9 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
                 config.title = config.title || router.convertRouteToTitle(config.route);
                 config.moduleId = config.moduleId || router.convertRouteToModuleId(config.route);
                 config.hash = config.hash || router.convertRouteToHash(config.route);
+                if (config.hasSubRoutes == true) {
+                    config.route = config.route + '*subRoutes';
+                }
                 config.routePattern = routeStringToRegExp(config.route);
             }else{
                 config.routePattern = config.route;


### PR DESCRIPTION
I'd like to propose an alternative to loading subroutes using *details which uses a specific property which signifies that the route has subroutes.

The suggested code is a simple hack to allow the property.  I'd certainly welcome alternative cleaner ways of doing it that would offer the same functionality.
