### PR TITLE
Correctly position dialog

### DIFF
--- a/src/plugins/js/dialog.js
+++ b/src/plugins/js/dialog.js
@@ -377,10 +377,15 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
                 return !(this.style.width && this.style.height) && !($this.attr("width") && $this.attr("height"));
             });
 
+            $child.data("predefinedWidth", $child.get(0).style.width);
+
             var setDialogPosition = function () {
                 //Setting a short timeout is need in IE8, otherwise we could do this straight away
                 setTimeout(function () {
-                    $child.css({ width: '' }); //Reset width
+                    //We will clear and then set width for dialogs without width set 
+                    if (!$child.data("predefinedWidth")) {
+                        $child.css({ width: '' }); //Reset width
+                    }
                     var width = $child.outerWidth(false);
                     var height = $child.outerHeight(false);
                     var windowHeight = $(window).height();
@@ -389,7 +394,12 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
                     $child.css({
                         'margin-top': (-constrainedHeight / 2).toString() + 'px',
                         'margin-left': (-width / 2).toString() + 'px'
-                    }).outerWidth(width);
+                    });
+
+                    if (!$child.data("predefinedWidth")) {
+                        //Ensure the correct width after margin-left has been set
+                        $child.outerWidth(width);
+                    }
 
                     if (height > windowHeight) {
                         $child.css("overflow-y", "auto");


### PR DESCRIPTION
Hello!

I noticed that Durandal's modal dialog was not centered properly. I made the following fixes:
## Take box-sizing:border-box into account

The previous implementation used jQuery width() and height() for determining the width and height of the dialog. This does not work correctly, when box-sizing: border-box is set, such is the case with Zurb Foundation 4.0 and Twitter Bootstrap 3.0. Both use \* { box-sizing: border-box; } CSS-declaration.

Instead, we use now jQuery outerWidth and outerHeight to determine the correct width and height. As of jQuery 1.8, we can also use them as setters, which facilitates our problems with box-sizing. We also set the dialog width after determining the correct margin-left to ensure that the dialog stays at the correct size even after the margins are changed.
## Handled situations, when the dialog is higher than the window height.

Previously, there was no handling of the case when the dialog was higher than the window height. It simply showed partially, without any chance to scroll to the overflowing parts.

Now, the dialog maxes out at the window height, and then provides a scroll bar to scroll to overflowing content via overflow-y: auto.
## Handled a situation with images with unknown sizes in the modal

Previously images that loaded after the modal was shown caused it to be positioned incorrectly. In other words, the dialog did not reposition itself after images, which were within it, completed loading and gained their width and height.

Now, we subscribe to the loading event of the images without predefined height and width, and after they load, we reposition the dialog. I think this is the simplest approach. We could also define an animation to smoothly reposition and resize the dialog, but I opted not to do it, because it is a bit opinionated and maybe not everyone likes it. And anyways it would be harder to test.
## Feedback

Please let me know how you like this solution!
