### PR TITLE
Bugfix: Activate function not get triggered when coming back to new child route

### DIFF
--- a/src/durandal/js/activator.js
+++ b/src/durandal/js/activator.js
@@ -284,11 +284,16 @@ define(['durandal/system', 'knockout'], function (system, ko) {
                 }
 
                 computed.isActivating(true);
-
+				
+				var activateCallback = function (result) {
+					activeData = newActivationData;
+					computed.isActivating(false);
+					dfd.resolve(result);
+                };
+				
                 var currentItem = activeItem();
                 if (settings.areSameItem(currentItem, newItem, activeData, newActivationData)) {
-                    computed.isActivating(false);
-                    dfd.resolve(true);
+					activate(newItem, activeItem, activateCallback, newActivationData);
                     return;
                 }
 
@@ -300,11 +305,7 @@ define(['durandal/system', 'knockout'], function (system, ko) {
                                     deactivate(currentItem, settings.closeOnDeactivate, settings, dfd2);
                                 }).promise().then(function () {
                                     newItem = settings.beforeActivate(newItem, newActivationData);
-                                    activate(newItem, activeItem, function (result) {
-                                        activeData = newActivationData;
-                                        computed.isActivating(false);
-                                        dfd.resolve(result);
-                                    }, newActivationData);
+                                    activate(newItem, activeItem, activateCallback, newActivationData);
                                 });
                             } else {
                                 if (viaSetter) {


### PR DESCRIPTION
When navigating between two child routers (after the first time when going back forth) activate function does not get triggered in viewmodel.

e.g /analysis/steps/success/7 to /report/summary/7 where there are two child routes within steps/ and report/

Included the fix to call "activate" function even the current and new items are same.
