### PR TITLE
Improvedquerystring

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -467,15 +467,15 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
                 }
 
                 var parts = pair.split('='),
-		    key = parts[0],
-		    value = parts[1] && decodeURIComponent(parts[1].replace(/\+/g, ' '));
+                    key = parts[0],
+                    value = parts[1] && decodeURIComponent(parts[1].replace(/\+/g, ' '));
 
-		if (queryObject[key]) {
-		    queryObject[key] = [queryObject[key], value];
-		}
-		else {
-		    queryObject[key] = value;
-		}
+                if (queryObject[key]) {
+                    queryObject[key] = [queryObject[key], value];
+                }
+                else {
+                    queryObject[key] = value;
+                }
             }
 
             return queryObject;

--- a/test/spec.js
+++ b/test/spec.js
@@ -28,3 +28,4 @@ page.onLoadFinished = function () {
 };
 
 page.open('spec.html');
+

--- a/test/specs/router.spec.js
+++ b/test/specs/router.spec.js
@@ -1,33 +1,34 @@
 define(['plugins/router'], function(router) {
-	describe('plugins/router', function() {
-		describe('parseQueryString', function() {
-			it('returns null when the queryString parameter is an empty string', function() {
-				var res = router.parseQueryString('');
-				expect(res).toBeNull();
-			});
+    describe('plugins/router', function() {
+        describe('parseQueryString', function() {
+            it('returns null when the queryString parameter is an empty string', function() {
+                var res = router.parseQueryString('');
+                expect(res).toBeNull();
+            });
 
-			it('returns null when the queryString parameter is null', function() {
-				var res = router.parseQueryString(null);
-				expect(null).toBeNull();
-			});
+            it('returns null when the queryString parameter is null', function() {
+                var res = router.parseQueryString(null);
+                expect(null).toBeNull();
+            });
 
-			it('returns object when queryString = "a=1"', function() {
-				var res = router.parseQueryString('a=1'),
-				    exp = { a: '1' };
-				expect(res).toEqual(exp);
-			});
+            it('returns object when queryString = "a=1"', function() {
+                var res = router.parseQueryString('a=1'),
+                    exp = { a: '1' };
+                expect(res).toEqual(exp);
+            });
 
-			it('returns object when queryString = "a=1&b=2"', function() {
-				var res = router.parseQueryString('a=1&b=2'),
-				    exp = { a: '1', b: '2' };
-				expect(res).toEqual(exp);
-			});
+            it('returns object when queryString = "a=1&b=2"', function() {
+                var res = router.parseQueryString('a=1&b=2'),
+                    exp = { a: '1', b: '2' };
+                expect(res).toEqual(exp);
+            });
 
-			it('returns object when queryString = "a=1&b=2&b=3"', function() {
-				var res = router.parseQueryString('a=1&b=2&b=3'),
-				    exp = { a: '1', b: ['2', '3'] };
-				expect(res).toEqual(exp);
-			});
-		});
-	});
+            it('returns object when queryString = "a=1&b=2&b=3"', function() {
+                var res = router.parseQueryString('a=1&b=2&b=3'),
+                    exp = { a: '1', b: ['2', '3'] };
+                expect(res).toEqual(exp);
+            });
+        });
+    });
 });
+


### PR DESCRIPTION
Hi,

First, I'd like to praise the team for the new router design. Especially the support for query strings is greatly appreciated! 

I've added support for query strings with multiple occurences of the same key. Instead of overwriting the previous value. The query string "?a=1&b=2&b=3" is now parsed as { a: '1', b: ['2', '3'] } instead of { a: '1', b: '3' }.
