### PR TITLE
Append startRoute option to router activate options

### DIFF
--- a/src/plugins/js/history.js
+++ b/src/plugins/js/history.js
@@ -155,7 +155,7 @@ define(['durandal/system', 'jquery'], function (system, $) {
         }
 
         if (!history.options.silent) {
-            return history.loadUrl();
+            return history.loadUrl(options.startRoute);
         }
     };
 

--- a/src/typescript/durandal/durandal.d.ts
+++ b/src/typescript/durandal/durandal.d.ts
@@ -1021,6 +1021,11 @@ declare module 'plugins/history' {
          * @default false
          */
         silent?: boolean;
+
+        /**
+         * Override default history init behavior by navigating directly to this route.
+         */
+        startRoute?: string;
     }
 
     interface NavigationOptions {


### PR DESCRIPTION
Append startRoute option to router activate options which override default history init behavior by navigating directly to this route.

Very useful when trying to save and restore application state especially when developping Desktop and Windows 8 application.
