### PR TITLE
Throw rejected promise error on next tick.

### DIFF
--- a/src/durandal/js/activator.js
+++ b/src/durandal/js/activator.js
@@ -68,8 +68,8 @@ define(['durandal/system', 'knockout'], function (system, ko) {
                     settings.afterDeactivate(item, close, setter);
                     dfd.resolve(true);
                 }, function(reason) {
-                    setTimout(function(){
-                        system.log(reason);
+                    setTimeout(function(){
+                        system.error(reason);
                     }, 0);
                     dfd.resolve(false);
                 });


### PR DESCRIPTION
Currently when an error occur during asynchronous loading in the activate function, the promise in its rejected state will be printed to the console log using system.log. This is very often difficult to see when doing development.

I propose that the error is more forcefully propagated, so that it is thrown in a synchronous manner on the next tick (using setTimeout in this implementation). The error will thrown in a "normal" manner, and be much more visible.
