### PR TITLE
Changed entrance animations callbacks from complete to always.

### DIFF
--- a/src/transitions/js/entrance.js
+++ b/src/transitions/js/entrance.js
@@ -55,14 +55,18 @@ define(['durandal/system', 'durandal/composition', 'jquery'], function(system, c
                     var $child = $(context.child);
 
                     $child.css(startValues);
-                    $child.animate(endValues, duration, 'swing', function () {
-                        $child.css(clearValues);
-                        endTransition();
+                    $child.animate(endValues, {
+                        duration: duration,
+                        easing: 'swing',
+                        always: function () {
+                            $child.css(clearValues);
+                            endTransition();
+                        }
                     });
                 }
 
                 if (context.activeView) {
-                    $(context.activeView).fadeOut(fadeOutDuration, startTransition);
+                    $(context.activeView).fadeOut({ duration: fadeOutDuration, always: startTransition });
                 } else {
                     startTransition();
                 }


### PR DESCRIPTION
I've run in some issues when switching views fast while an animation was running, the animation get's never completed. It will fail when cache-views is not defined or false. Fixed by changing complete to always. Even when the animation fails, the transition will be resolved.
