### PR TITLE
[plugins/router] set `isProcessing` to false on `completeNavigation`

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -207,6 +207,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
                 router.updateDocumentTitle(instance, instruction);
             }
 
+            isProcessing(false);
             rootRouter.explicitNavigation = false;
             rootRouter.navigatingBack = false;
             router.trigger('router:navigation:complete', instance, instruction, router);


### PR DESCRIPTION
While building my SPA with Durandal I ran into (edge) cases (login/logout with a rebuild of the router) where the router would hang the app as it would not stop navigating anymore as `isProcessing` was never reset.

Force-setting `isProcessing` to `false` on `completeNavigation` (just like on cancel, et. al.) fixed this for me while not affecting any other behavior of the router.
