### PR TITLE
Check for obj.prototype before reading or assigning

### DIFF
--- a/src/durandal/js/system.js
+++ b/src/durandal/js/system.js
@@ -113,7 +113,7 @@ define(['require', 'jquery'], function(require, $) {
                 return null;
             }
 
-            if (typeof obj == 'function') {
+            if (typeof obj == 'function' && obj.prototype) {
                 return obj.prototype.__moduleId__;
             }
 
@@ -134,7 +134,7 @@ define(['require', 'jquery'], function(require, $) {
                 return;
             }
 
-            if (typeof obj == 'function') {
+            if (typeof obj == 'function' && obj.prototype) {
                 obj.prototype.__moduleId__ = id;
                 return;
             }


### PR DESCRIPTION
When using the ['lodash-amd'](https://npmjs.org/package/lodash-amd) package, `setModuleId` fails, since the functions defined by LoDash aren't the type that have a `.prototype` property.

This just checks that `obj.prototype` exists before assigning or reading it.
