### PR TITLE
Fix bug where IE will fail to load view due to wrong typeName

### DIFF
--- a/src/durandal/js/viewLocator.js
+++ b/src/durandal/js/viewLocator.js
@@ -98,7 +98,7 @@ define(['durandal/system', 'durandal/viewEngine'], function (system, viewEngine)
             var funcNameRegex = /function (.{1,})\(/;
             var results = (funcNameRegex).exec((obj).constructor.toString());
             var typeName = (results && results.length > 1) ? results[1] : "";
-
+            typeName = typeName.trim();
             return 'views/' + typeName;
         },
         /**


### PR DESCRIPTION
In the 'determineFallbackViewId' function in viewLocator, the code will
attempt to read out constructor function name using a regex. The regex
assume that there are no trailing spaces between the function name and the
paranthesis. IE seem to inject a space there. This causes the function to
return something like 'views/MyConstructor .html' (notice the space)
