### PR TITLE
Pass all arguments to interpretResponse function.

### DIFF
--- a/src/durandal/js/activator.js
+++ b/src/durandal/js/activator.js
@@ -136,7 +136,7 @@ define(['durandal/system', 'knockout'], function (system, ko) {
                 if (resultOrPromise.then) {
                     resultOrPromise.then(function(result) {
                         settings.lifecycleData = result;
-                        dfd.resolve(settings.interpretResponse(result));
+                        dfd.resolve(settings.interpretResponse.apply(settings, arguments));
                     }, function(reason) {
                         system.error(reason);
                         dfd.resolve(false);
@@ -173,7 +173,7 @@ define(['durandal/system', 'knockout'], function (system, ko) {
                 if (resultOrPromise.then) {
                     resultOrPromise.then(function(result) {
                         settings.lifecycleData = result;
-                        dfd.resolve(settings.interpretResponse(result));
+                        dfd.resolve(settings.interpretResponse.apply(settings, arguments));
                     }, function(reason) {
                         system.error(reason);
                         dfd.resolve(false);


### PR DESCRIPTION
We may pass multiple parameters to deferred.resolve, so then callback may get multiple arguments and we may want to use these parameters in interpretResponse. This is also backward compatible.
