### PR TITLE
Allow more granular control for module comparison during activation

### DIFF
--- a/src/durandal/js/activator.js
+++ b/src/durandal/js/activator.js
@@ -1,9 +1,4 @@
-/**
- * Durandal 2.0.1 Copyright (c) 2012 Blue Spire Consulting, Inc. All Rights Reserved.
- * Available via the MIT license.
- * see: http://durandaljs.com or https://github.com/BlueSpire/Durandal for details.
- */
-/**
+﻿/**
  * The activator module encapsulates all logic related to screen/component activation.
  * An activator is essentially an asynchronous state machine that understands a particular state transition protocol.
  * The protocol ensures that the following series of events always occur: `canDeactivate` (previous state), `canActivate` (new state), `deactivate` (previous state), `activate` (new state).
@@ -224,7 +219,7 @@ define(['durandal/system', 'knockout'], function (system, ko) {
             });
         }).promise();
     };
-
+    
     /**
      * An activator is a read/write computed observable that enforces the activation lifecycle whenever changing values.
      * @class Activator


### PR DESCRIPTION
Currently, Durandal's activator uses a simple equality check to determine if two modules are the same (during `canActivate`). Most of the time this is fine, but there are occasions where a child module needs more granular control to determine if two modules are indeed the same.

An example of this would be a wizard designed to create a new account. You hit "Step 1", and then decide to cancel that request. Later, you go back to "Step 1" with a different account; Durandal checks and says that the modules are indeed the same, and as such, the `canActivate` method is not invoked (even though the active account has changed, and as such, canActivate needed to run).

This change allows for modules to define a `isSameItem` method, which the activator will invoke if present, in order to determine if two modules are the same. Implementations may return a deferred or a boolean to indicate the result of the comparison. If the method is not implemented, the activator uses the default logic (equality comparison) to check if two modules are the same.
