### PR TITLE
Added close button to template, and close on escape.

### DIFF
--- a/platforms/Bower/Durandal/js/plugins/dialog.js
+++ b/platforms/Bower/Durandal/js/plugins/dialog.js
@@ -39,6 +39,14 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     };
 
     /**
+     * Closes a message box.
+     * @method close
+     */
+    MessageBox.prototype.close = function () {
+      dialog.close(this);
+    };
+
+    /**
      * Provides the view to the composition system.
      * @method getView
      * @return {DOMElement} The view of the message box.
@@ -82,7 +90,8 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     MessageBox.defaultViewMarkup = [
         '<div data-view="plugins/messageBox" class="modal-content messageBox">',
             '<div class="modal-header">',
-                '<h3 data-bind="text: title"></h3>',
+                '<button type="button" class="close" data-bind="click: function () { close(); }" aria-hidden="true">&times;</button>',
+                '<h4 data-bind="text: title"></h4>',
             '</div>',
             '<div class="modal-body">',
                 '<p class="message" data-bind="text: message"></p>',
@@ -429,6 +438,10 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
 
             if ($child.hasClass('autoclose')) {
                 $(theDialog.blockout).click(function () {
+                    theDialog.close();
+                });
+                $(document).keyup(function (e) {
+                  if (e.keyCode === 27)
                     theDialog.close();
                 });
             }

--- a/platforms/HTML/Samples/lib/durandal/js/plugins/dialog.js
+++ b/platforms/HTML/Samples/lib/durandal/js/plugins/dialog.js
@@ -39,6 +39,14 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     };
 
     /**
+     * Closes a message box.
+     * @method close
+     */
+    MessageBox.prototype.close = function () {
+      dialog.close(this);
+    };
+
+    /**
      * Provides the view to the composition system.
      * @method getView
      * @return {DOMElement} The view of the message box.
@@ -82,7 +90,8 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     MessageBox.defaultViewMarkup = [
         '<div data-view="plugins/messageBox" class="modal-content messageBox">',
             '<div class="modal-header">',
-                '<h3 data-bind="text: title"></h3>',
+                '<button type="button" class="close" data-bind="click: function () { close(); }" aria-hidden="true">&times;</button>',
+                '<h4 data-bind="text: title"></h4>',
             '</div>',
             '<div class="modal-body">',
                 '<p class="message" data-bind="text: message"></p>',
@@ -429,6 +438,10 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
 
             if ($child.hasClass('autoclose')) {
                 $(theDialog.blockout).click(function () {
+                    theDialog.close();
+                });
+                $(document).keyup(function (e) {
+                  if (e.keyCode === 27)
                     theDialog.close();
                 });
             }

--- a/platforms/HTML/StarterKit/lib/durandal/js/plugins/dialog.js
+++ b/platforms/HTML/StarterKit/lib/durandal/js/plugins/dialog.js
@@ -39,6 +39,14 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     };
 
     /**
+     * Closes a message box.
+     * @method close
+     */
+    MessageBox.prototype.close = function () {
+      dialog.close(this);
+    };
+
+    /**
      * Provides the view to the composition system.
      * @method getView
      * @return {DOMElement} The view of the message box.
@@ -82,7 +90,8 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     MessageBox.defaultViewMarkup = [
         '<div data-view="plugins/messageBox" class="modal-content messageBox">',
             '<div class="modal-header">',
-                '<h3 data-bind="text: title"></h3>',
+                '<button type="button" class="close" data-bind="click: function () { close(); }" aria-hidden="true">&times;</button>',
+                '<h4 data-bind="text: title"></h4>',
             '</div>',
             '<div class="modal-body">',
                 '<p class="message" data-bind="text: message"></p>',
@@ -429,6 +438,10 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
 
             if ($child.hasClass('autoclose')) {
                 $(theDialog.blockout).click(function () {
+                    theDialog.close();
+                });
+                $(document).keyup(function (e) {
+                  if (e.keyCode === 27)
                     theDialog.close();
                 });
             }

--- a/platforms/Microsoft.NET/Nuget/Durandal.Transitions/content/Scripts/durandal/plugins/dialog.js
+++ b/platforms/Microsoft.NET/Nuget/Durandal.Transitions/content/Scripts/durandal/plugins/dialog.js
@@ -39,6 +39,14 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     };
 
     /**
+     * Closes a message box.
+     * @method close
+     */
+    MessageBox.prototype.close = function () {
+      dialog.close(this);
+    };
+
+    /**
      * Provides the view to the composition system.
      * @method getView
      * @return {DOMElement} The view of the message box.
@@ -82,7 +90,8 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     MessageBox.defaultViewMarkup = [
         '<div data-view="plugins/messageBox" class="modal-content messageBox">',
             '<div class="modal-header">',
-                '<h3 data-bind="text: title"></h3>',
+                '<button type="button" class="close" data-bind="click: function () { close(); }" aria-hidden="true">&times;</button>',
+                '<h4 data-bind="text: title"></h4>',
             '</div>',
             '<div class="modal-body">',
                 '<p class="message" data-bind="text: message"></p>',
@@ -429,6 +438,10 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
 
             if ($child.hasClass('autoclose')) {
                 $(theDialog.blockout).click(function () {
+                    theDialog.close();
+                });
+                $(document).keyup(function (e) {
+                  if (e.keyCode === 27)
                     theDialog.close();
                 });
             }

--- a/platforms/Microsoft.NET/Nuget/Durandal/content/Scripts/durandal/plugins/dialog.js
+++ b/platforms/Microsoft.NET/Nuget/Durandal/content/Scripts/durandal/plugins/dialog.js
@@ -39,6 +39,14 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     };
 
     /**
+     * Closes a message box.
+     * @method close
+     */
+    MessageBox.prototype.close = function () {
+      dialog.close(this);
+    };
+
+    /**
      * Provides the view to the composition system.
      * @method getView
      * @return {DOMElement} The view of the message box.
@@ -82,7 +90,8 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     MessageBox.defaultViewMarkup = [
         '<div data-view="plugins/messageBox" class="modal-content messageBox">',
             '<div class="modal-header">',
-                '<h3 data-bind="text: title"></h3>',
+                '<button type="button" class="close" data-bind="click: function () { close(); }" aria-hidden="true">&times;</button>',
+                '<h4 data-bind="text: title"></h4>',
             '</div>',
             '<div class="modal-body">',
                 '<p class="message" data-bind="text: message"></p>',
@@ -429,6 +438,10 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
 
             if ($child.hasClass('autoclose')) {
                 $(theDialog.blockout).click(function () {
+                    theDialog.close();
+                });
+                $(document).keyup(function (e) {
+                  if (e.keyCode === 27)
                     theDialog.close();
                 });
             }

--- a/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/plugins/dialog.js
+++ b/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/plugins/dialog.js
@@ -39,6 +39,14 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     };
 
     /**
+     * Closes a message box.
+     * @method close
+     */
+    MessageBox.prototype.close = function () {
+      dialog.close(this);
+    };
+
+    /**
      * Provides the view to the composition system.
      * @method getView
      * @return {DOMElement} The view of the message box.
@@ -82,7 +90,8 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     MessageBox.defaultViewMarkup = [
         '<div data-view="plugins/messageBox" class="modal-content messageBox">',
             '<div class="modal-header">',
-                '<h3 data-bind="text: title"></h3>',
+                '<button type="button" class="close" data-bind="click: function () { close(); }" aria-hidden="true">&times;</button>',
+                '<h4 data-bind="text: title"></h4>',
             '</div>',
             '<div class="modal-body">',
                 '<p class="message" data-bind="text: message"></p>',
@@ -429,6 +438,10 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
 
             if ($child.hasClass('autoclose')) {
                 $(theDialog.blockout).click(function () {
+                    theDialog.close();
+                });
+                $(document).keyup(function (e) {
+                  if (e.keyCode === 27)
                     theDialog.close();
                 });
             }

--- a/platforms/Microsoft.NET/StarterKit/vstemplate/DurandalTemplate/DurandalTemplate/Scripts/durandal/plugins/dialog.js
+++ b/platforms/Microsoft.NET/StarterKit/vstemplate/DurandalTemplate/DurandalTemplate/Scripts/durandal/plugins/dialog.js
@@ -39,6 +39,14 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     };
 
     /**
+     * Closes a message box.
+     * @method close
+     */
+    MessageBox.prototype.close = function () {
+      dialog.close(this);
+    };
+
+    /**
      * Provides the view to the composition system.
      * @method getView
      * @return {DOMElement} The view of the message box.
@@ -82,7 +90,8 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     MessageBox.defaultViewMarkup = [
         '<div data-view="plugins/messageBox" class="modal-content messageBox">',
             '<div class="modal-header">',
-                '<h3 data-bind="text: title"></h3>',
+                '<button type="button" class="close" data-bind="click: function () { close(); }" aria-hidden="true">&times;</button>',
+                '<h4 data-bind="text: title"></h4>',
             '</div>',
             '<div class="modal-body">',
                 '<p class="message" data-bind="text: message"></p>',
@@ -429,6 +438,10 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
 
             if ($child.hasClass('autoclose')) {
                 $(theDialog.blockout).click(function () {
+                    theDialog.close();
+                });
+                $(document).keyup(function (e) {
+                  if (e.keyCode === 27)
                     theDialog.close();
                 });
             }

--- a/platforms/Mimosa/StarterKit/assets/javascripts/vendor/durandal/plugins/dialog.js
+++ b/platforms/Mimosa/StarterKit/assets/javascripts/vendor/durandal/plugins/dialog.js
@@ -39,6 +39,14 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     };
 
     /**
+     * Closes a message box.
+     * @method close
+     */
+    MessageBox.prototype.close = function () {
+      dialog.close(this);
+    };
+
+    /**
      * Provides the view to the composition system.
      * @method getView
      * @return {DOMElement} The view of the message box.
@@ -82,7 +90,8 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     MessageBox.defaultViewMarkup = [
         '<div data-view="plugins/messageBox" class="modal-content messageBox">',
             '<div class="modal-header">',
-                '<h3 data-bind="text: title"></h3>',
+                '<button type="button" class="close" data-bind="click: function () { close(); }" aria-hidden="true">&times;</button>',
+                '<h4 data-bind="text: title"></h4>',
             '</div>',
             '<div class="modal-body">',
                 '<p class="message" data-bind="text: message"></p>',
@@ -429,6 +438,10 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
 
             if ($child.hasClass('autoclose')) {
                 $(theDialog.blockout).click(function () {
+                    theDialog.close();
+                });
+                $(document).keyup(function (e) {
+                  if (e.keyCode === 27)
                     theDialog.close();
                 });
             }

--- a/src/plugins/js/dialog.js
+++ b/src/plugins/js/dialog.js
@@ -1,4 +1,9 @@
-﻿/**
+/**
+ * Durandal 2.1.0 Copyright (c) 2012 Blue Spire Consulting, Inc. All Rights Reserved.
+ * Available via the MIT license.
+ * see: http://durandaljs.com or https://github.com/BlueSpire/Durandal for details.
+ */
+/**
  * The dialog module enables the display of message boxes, custom modal dialogs and other overlays or slide-out UI abstractions. Dialogs are constructed by the composition system which interacts with a user defined dialog context. The dialog module enforced the activator lifecycle.
  * @module dialog
  * @requires system
@@ -31,6 +36,14 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
      */
     MessageBox.prototype.selectOption = function (dialogResult) {
         dialog.close(this, dialogResult);
+    };
+
+    /**
+     * Closes a message box.
+     * @method close
+     */
+    MessageBox.prototype.close = function () {
+      dialog.close(this);
     };
 
     /**
@@ -77,7 +90,8 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     MessageBox.defaultViewMarkup = [
         '<div data-view="plugins/messageBox" class="modal-content messageBox">',
             '<div class="modal-header">',
-                '<h3 data-bind="text: title"></h3>',
+                '<button type="button" class="close" data-bind="click: function () { close(); }" aria-hidden="true">&times;</button>',
+                '<h4 data-bind="text: title"></h4>',
             '</div>',
             '<div class="modal-body">',
                 '<p class="message" data-bind="text: message"></p>',
@@ -424,6 +438,10 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
 
             if ($child.hasClass('autoclose')) {
                 $(theDialog.blockout).click(function () {
+                    theDialog.close();
+                });
+                $(document).keyup(function (e) {
+                  if (e.keyCode === 27)
                     theDialog.close();
                 });
             }


### PR DESCRIPTION
What title says.

I also changed the template to use h4 for the title, since that is the standard in BS3.

The close-on-escape functionality is only applied on dialogs where the autoclose option is enabled.
