### PR TITLE
Fix for #412: Route configured as RegExp object throwing error

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -389,7 +389,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
         function configureRoute(config){
             router.trigger('router:route:before-config', config, router);
 
-            if (!system.isRegExp(config)) {
+            if (!system.isRegExp(config.route)) {
                 config.title = config.title || router.convertRouteToTitle(config.route);
                 config.moduleId = config.moduleId || router.convertRouteToModuleId(config.route);
                 config.hash = config.hash || router.convertRouteToHash(config.route);


### PR DESCRIPTION
https://github.com/BlueSpire/Durandal/issues/412
