### PR TITLE
Added support for null routes.

### DIFF
--- a/src/durandal/js/activator.js
+++ b/src/durandal/js/activator.js
@@ -85,36 +85,27 @@ define(['durandal/system', 'knockout'], function (system, ko) {
     }
 
     function activate(newItem, activeItem, callback, activationData) {
-        if (newItem) {
-            if (newItem.activate) {
-                system.log('Activating', newItem);
-
-                var result;
-                try {
-                    result = invoke(newItem, 'activate', activationData);
-                } catch (error) {
-                    system.error(error);
-                    callback(false);
-                    return;
-                }
-
-                if (result && result.then) {
-                    result.then(function() {
-                        activeItem(newItem);
-                        callback(true);
-                    }, function(reason) {
-                        system.log(reason);
-                        callback(false);
-                    });
-                } else {
-                    activeItem(newItem);
-                    callback(true);
-                }
-            } else {
+        var result; 
+        if (newItem && newItem.activate) {
+            system.log('Activating', newItem);
+            try {
+                result = invoke(newItem, 'activate', activationData);
+            } catch (error) {
+                system.error(error);
+                callback(false);
+                return;
+            }
+        }
+        if (result && result.then) {
+            result.then(function() {
                 activeItem(newItem);
                 callback(true);
-            }
+            }, function(reason) {
+                system.log(reason);
+                callback(false);
+            });
         } else {
+            activeItem(newItem);
             callback(true);
         }
     }


### PR DESCRIPTION
 If you configure a route on the router

.map({ route: 'empty', moduleId: null })

then, navigating to '#/empty' will empty the router element.
