### PR TITLE
Rejected promise from 'onactivate' and 'activate' is now written to 'system.error'

### DIFF
--- a/src/durandal/js/activator.js
+++ b/src/durandal/js/activator.js
@@ -68,7 +68,7 @@ define(['durandal/system', 'knockout'], function (system, ko) {
                     settings.afterDeactivate(item, close, setter);
                     dfd.resolve(true);
                 }, function(reason) {
-                    system.error(reasor);
+                    system.error(reason);
                     dfd.resolve(false);
                 });
             } else {


### PR DESCRIPTION
If an exception occur in an activate/onactivate the error will be written to system.log. The error object will then not be properly handled by durandal.
