### PR TITLE
Fix bug where guardRoute cannot redirect to ''

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -291,7 +291,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
          */
         function handleGuardedRoute(activator, instance, instruction) {
             var resultOrPromise = router.guardRoute(instance, instruction);
-            if (resultOrPromise) {
+            if (resultOrPromise || resultOrPromise === '') {
                 if (resultOrPromise.then) {
                     resultOrPromise.then(function(result) {
                         if (result) {


### PR DESCRIPTION
If you want to redirect to the home of the app via guardRoute the empty route string is interpreted as false and the navigation is cancelled.
