### PR TITLE
Stops activate being called twice when composing an activator (#386).

### DIFF
--- a/src/durandal/js/composition.js
+++ b/src/durandal/js/composition.js
@@ -529,7 +529,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
             if (moduleId) {
                 settings = {
                     model: settings,
-                    activate: true
+                    activate: !activatorPresent
                 };
 
                 return settings;


### PR DESCRIPTION
Ran into same issue as #386 when calling activateItem passing in a view model instance which was then composed. 
The same issue seems to occur in the Durandal samples on the Master Detail page when activate is called twice.
