### PR TITLE
Remove *details part when hash generated

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -144,7 +144,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
             /**
              * The route configurations that have been designated as displayable in a nav ui (nav:true).
              * @property {KnockoutObservableArray} navigationModel
-             */
+             */convertroutetoh
             navigationModel: ko.observableArray([]),
             /**
              * The active item/screen based on the current navigation state.
@@ -601,6 +601,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
          * @return {string} The hash.
          */
         router.convertRouteToHash = function(route) {
+            route = route.replace(/\*.*$/, '');
             if(router.relativeToParentRouter){
                 var instruction = router.parent.activeInstruction(),
                     hash = instruction.config.hash + '/' + route;


### PR DESCRIPTION
Default implementation of convertRouteToHash doesn't remove "_details" (or such patterns when working with child routers) from the end of routes. Such "_details" parts are not usable in any scenario, but removing them makes developer's work easy (Specially when we have child routers).

I know i can change this default implementation form outside, but it's messy to edit that for both root-router and child routers (Let me know if i'm wrong, but replacing these hooks on entire module only replaces them in root-router and i'll have to replace it for each child router too).
## 

As a side note, it's almost a year that I haven't been in touch with this framework and SPA development, and now that i'm back I see it has become amazing. Thanks a lot for all the hard work.
