### PR TITLE
Fixed bug in router where querystring in child routes causes Route Not Found errors

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -500,7 +500,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
             if(router.relativeToParentRouter){
                 var instruction = this.parent.activeInstruction();
-                coreFragment = instruction.params.join('/');
+				coreFragment = queryIndex == -1 ? instruction.params.join('/') : instruction.params.slice(0, -1).join('/');
 
                 if(coreFragment && coreFragment.charAt(0) == '/'){
                     coreFragment = coreFragment.substr(1);


### PR DESCRIPTION
If you use a child route and add a querystring the route will return Route Not Found. This is because querystring params get added to instruction.params from the parent route and all params are joined to created the new fragment resulting in fragments like 'parent/child/[object Object]' which causes the issue. I changed the join line in router.loadUrl to check for a querystring and if it exists to drop the last params value before joining into a string.
