### PR TITLE
Typo Correction on Modals Documentation

### DIFF
--- a/docs/2.x/Showing-Message-Boxes-And-Modals.html.md
+++ b/docs/2.x/Showing-Message-Boxes-And-Modals.html.md
@@ -1,5 +1,5 @@
 ---
-title: Docs - Showing Mssage Boxes and Modals
+title: Docs - Showing Message Boxes and Modals
 layout: docs
 tags: ['docs','modals','how to']
 ---


### PR DESCRIPTION
This was affecting google search results for 'durandal modal'
