### PR TITLE
Fix a bug that causes routes to be relative even when in pushState

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -876,7 +876,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                 while(i--){
                     var current = routes[i];
-                    current.hash = current.hash.replace('#', '');
+                    current.hash = current.hash.replace('#', '/');
                 }
             }
 


### PR DESCRIPTION
Fix a bug that causes routes to be relative even when in pushState. Normal link interaction handles this because Durandal intercepts it, but if a user opens a link 'in a new tab' Durandal doesn't intercept it, and a relative link is opened, which fails.

With this change, `href`'s bound to the hash will still work correctly when middle-clicked. Navigation is not affected otherwise.
