### PR TITLE
Abort composition when the context is changed during activation

### DIFF
--- a/platforms/Bower/Durandal/js/composition.js
+++ b/platforms/Bower/Durandal/js/composition.js
@@ -450,6 +450,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
         },
         bindAndShow: function (child, context, skipActivation) {
             context.child = child;
+            context.parent.__composition_context = context;
 
             if (context.cacheViews) {
                 context.composingNewView = (ko.utils.arrayIndexOf(context.viewElements, child) == -1);
@@ -458,46 +459,53 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
             }
 
             tryActivate(context, function () {
-                if (context.binding) {
-                    context.binding(context.child, context.parent, context);
-                }
+                if (context.parent.__composition_context == context) {
+                    delete context.parent.__composition_context;
 
-                if (context.preserveContext && context.bindingContext) {
-                    if (context.composingNewView) {
-                        if(context.parts){
-                            replaceParts(context);
-                        }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bindContext(context.bindingContext, child, context.model);
+                    if (context.binding) {
+                        context.binding(context.child, context.parent, context);
                     }
-                } else if (child) {
-                    var modelToBind = context.model || dummyModel;
-                    var currentModel = ko.dataFor(child);
 
-                    if (currentModel != modelToBind) {
-                        if (!context.composingNewView) {
-                            ko.removeNode(child);
-                            viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
-                                composition.bindAndShow(recreatedView, context, true);
-                            });
-                            return;
+                    if (context.preserveContext && context.bindingContext) {
+                        if (context.composingNewView) {
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bindContext(context.bindingContext, child, context.model);
                         }
+                    } else if (child) {
+                        var modelToBind = context.model || dummyModel;
+                        var currentModel = ko.dataFor(child);
 
-                        if(context.parts){
-                            replaceParts(context);
+                        if (currentModel != modelToBind) {
+                            if (!context.composingNewView) {
+                                ko.removeNode(child);
+                                viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
+                                    composition.bindAndShow(recreatedView, context, true);
+                                });
+                                return;
+                            }
+
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bind(modelToBind, child);
                         }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bind(modelToBind, child);
                     }
-                }
 
-                composition.finalize(context);
+                    composition.finalize(context);
+                } else {
+                    endComposition();
+                    cleanUp(context);
+                }
             }, skipActivation);
         },
         /**

--- a/platforms/HTML/Samples/lib/durandal/js/composition.js
+++ b/platforms/HTML/Samples/lib/durandal/js/composition.js
@@ -450,6 +450,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
         },
         bindAndShow: function (child, context, skipActivation) {
             context.child = child;
+            context.parent.__composition_context = context;
 
             if (context.cacheViews) {
                 context.composingNewView = (ko.utils.arrayIndexOf(context.viewElements, child) == -1);
@@ -458,46 +459,53 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
             }
 
             tryActivate(context, function () {
-                if (context.binding) {
-                    context.binding(context.child, context.parent, context);
-                }
+                if (context.parent.__composition_context == context) {
+                    delete context.parent.__composition_context;
 
-                if (context.preserveContext && context.bindingContext) {
-                    if (context.composingNewView) {
-                        if(context.parts){
-                            replaceParts(context);
-                        }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bindContext(context.bindingContext, child, context.model);
+                    if (context.binding) {
+                        context.binding(context.child, context.parent, context);
                     }
-                } else if (child) {
-                    var modelToBind = context.model || dummyModel;
-                    var currentModel = ko.dataFor(child);
 
-                    if (currentModel != modelToBind) {
-                        if (!context.composingNewView) {
-                            ko.removeNode(child);
-                            viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
-                                composition.bindAndShow(recreatedView, context, true);
-                            });
-                            return;
+                    if (context.preserveContext && context.bindingContext) {
+                        if (context.composingNewView) {
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bindContext(context.bindingContext, child, context.model);
                         }
+                    } else if (child) {
+                        var modelToBind = context.model || dummyModel;
+                        var currentModel = ko.dataFor(child);
 
-                        if(context.parts){
-                            replaceParts(context);
+                        if (currentModel != modelToBind) {
+                            if (!context.composingNewView) {
+                                ko.removeNode(child);
+                                viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
+                                    composition.bindAndShow(recreatedView, context, true);
+                                });
+                                return;
+                            }
+
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bind(modelToBind, child);
                         }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bind(modelToBind, child);
                     }
-                }
 
-                composition.finalize(context);
+                    composition.finalize(context);
+                } else {
+                    endComposition();
+                    cleanUp(context);
+                }
             }, skipActivation);
         },
         /**

--- a/platforms/HTML/StarterKit/lib/durandal/js/composition.js
+++ b/platforms/HTML/StarterKit/lib/durandal/js/composition.js
@@ -450,6 +450,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
         },
         bindAndShow: function (child, context, skipActivation) {
             context.child = child;
+            context.parent.__composition_context = context;
 
             if (context.cacheViews) {
                 context.composingNewView = (ko.utils.arrayIndexOf(context.viewElements, child) == -1);
@@ -458,46 +459,53 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
             }
 
             tryActivate(context, function () {
-                if (context.binding) {
-                    context.binding(context.child, context.parent, context);
-                }
+                if (context.parent.__composition_context == context) {
+                    delete context.parent.__composition_context;
 
-                if (context.preserveContext && context.bindingContext) {
-                    if (context.composingNewView) {
-                        if(context.parts){
-                            replaceParts(context);
-                        }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bindContext(context.bindingContext, child, context.model);
+                    if (context.binding) {
+                        context.binding(context.child, context.parent, context);
                     }
-                } else if (child) {
-                    var modelToBind = context.model || dummyModel;
-                    var currentModel = ko.dataFor(child);
 
-                    if (currentModel != modelToBind) {
-                        if (!context.composingNewView) {
-                            ko.removeNode(child);
-                            viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
-                                composition.bindAndShow(recreatedView, context, true);
-                            });
-                            return;
+                    if (context.preserveContext && context.bindingContext) {
+                        if (context.composingNewView) {
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bindContext(context.bindingContext, child, context.model);
                         }
+                    } else if (child) {
+                        var modelToBind = context.model || dummyModel;
+                        var currentModel = ko.dataFor(child);
 
-                        if(context.parts){
-                            replaceParts(context);
+                        if (currentModel != modelToBind) {
+                            if (!context.composingNewView) {
+                                ko.removeNode(child);
+                                viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
+                                    composition.bindAndShow(recreatedView, context, true);
+                                });
+                                return;
+                            }
+
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bind(modelToBind, child);
                         }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bind(modelToBind, child);
                     }
-                }
 
-                composition.finalize(context);
+                    composition.finalize(context);
+                } else {
+                    endComposition();
+                    cleanUp(context);
+                }
             }, skipActivation);
         },
         /**

--- a/platforms/Microsoft.NET/Nuget/Durandal.Transitions/content/Scripts/durandal/composition.js
+++ b/platforms/Microsoft.NET/Nuget/Durandal.Transitions/content/Scripts/durandal/composition.js
@@ -450,6 +450,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
         },
         bindAndShow: function (child, context, skipActivation) {
             context.child = child;
+            context.parent.__composition_context = context;
 
             if (context.cacheViews) {
                 context.composingNewView = (ko.utils.arrayIndexOf(context.viewElements, child) == -1);
@@ -458,46 +459,53 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
             }
 
             tryActivate(context, function () {
-                if (context.binding) {
-                    context.binding(context.child, context.parent, context);
-                }
+                if (context.parent.__composition_context == context) {
+                    delete context.parent.__composition_context;
 
-                if (context.preserveContext && context.bindingContext) {
-                    if (context.composingNewView) {
-                        if(context.parts){
-                            replaceParts(context);
-                        }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bindContext(context.bindingContext, child, context.model);
+                    if (context.binding) {
+                        context.binding(context.child, context.parent, context);
                     }
-                } else if (child) {
-                    var modelToBind = context.model || dummyModel;
-                    var currentModel = ko.dataFor(child);
 
-                    if (currentModel != modelToBind) {
-                        if (!context.composingNewView) {
-                            ko.removeNode(child);
-                            viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
-                                composition.bindAndShow(recreatedView, context, true);
-                            });
-                            return;
+                    if (context.preserveContext && context.bindingContext) {
+                        if (context.composingNewView) {
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bindContext(context.bindingContext, child, context.model);
                         }
+                    } else if (child) {
+                        var modelToBind = context.model || dummyModel;
+                        var currentModel = ko.dataFor(child);
 
-                        if(context.parts){
-                            replaceParts(context);
+                        if (currentModel != modelToBind) {
+                            if (!context.composingNewView) {
+                                ko.removeNode(child);
+                                viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
+                                    composition.bindAndShow(recreatedView, context, true);
+                                });
+                                return;
+                            }
+
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bind(modelToBind, child);
                         }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bind(modelToBind, child);
                     }
-                }
 
-                composition.finalize(context);
+                    composition.finalize(context);
+                } else {
+                    endComposition();
+                    cleanUp(context);
+                }
             }, skipActivation);
         },
         /**

--- a/platforms/Microsoft.NET/Nuget/Durandal/content/Scripts/durandal/composition.js
+++ b/platforms/Microsoft.NET/Nuget/Durandal/content/Scripts/durandal/composition.js
@@ -450,6 +450,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
         },
         bindAndShow: function (child, context, skipActivation) {
             context.child = child;
+            context.parent.__composition_context = context;
 
             if (context.cacheViews) {
                 context.composingNewView = (ko.utils.arrayIndexOf(context.viewElements, child) == -1);
@@ -458,46 +459,53 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
             }
 
             tryActivate(context, function () {
-                if (context.binding) {
-                    context.binding(context.child, context.parent, context);
-                }
+                if (context.parent.__composition_context == context) {
+                    delete context.parent.__composition_context;
 
-                if (context.preserveContext && context.bindingContext) {
-                    if (context.composingNewView) {
-                        if(context.parts){
-                            replaceParts(context);
-                        }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bindContext(context.bindingContext, child, context.model);
+                    if (context.binding) {
+                        context.binding(context.child, context.parent, context);
                     }
-                } else if (child) {
-                    var modelToBind = context.model || dummyModel;
-                    var currentModel = ko.dataFor(child);
 
-                    if (currentModel != modelToBind) {
-                        if (!context.composingNewView) {
-                            ko.removeNode(child);
-                            viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
-                                composition.bindAndShow(recreatedView, context, true);
-                            });
-                            return;
+                    if (context.preserveContext && context.bindingContext) {
+                        if (context.composingNewView) {
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bindContext(context.bindingContext, child, context.model);
                         }
+                    } else if (child) {
+                        var modelToBind = context.model || dummyModel;
+                        var currentModel = ko.dataFor(child);
 
-                        if(context.parts){
-                            replaceParts(context);
+                        if (currentModel != modelToBind) {
+                            if (!context.composingNewView) {
+                                ko.removeNode(child);
+                                viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
+                                    composition.bindAndShow(recreatedView, context, true);
+                                });
+                                return;
+                            }
+
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bind(modelToBind, child);
                         }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bind(modelToBind, child);
                     }
-                }
 
-                composition.finalize(context);
+                    composition.finalize(context);
+                } else {
+                    endComposition();
+                    cleanUp(context);
+                }
             }, skipActivation);
         },
         /**

--- a/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/composition.js
+++ b/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/composition.js
@@ -450,6 +450,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
         },
         bindAndShow: function (child, context, skipActivation) {
             context.child = child;
+            context.parent.__composition_context = context;
 
             if (context.cacheViews) {
                 context.composingNewView = (ko.utils.arrayIndexOf(context.viewElements, child) == -1);
@@ -458,46 +459,53 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
             }
 
             tryActivate(context, function () {
-                if (context.binding) {
-                    context.binding(context.child, context.parent, context);
-                }
+                if (context.parent.__composition_context == context) {
+                    delete context.parent.__composition_context;
 
-                if (context.preserveContext && context.bindingContext) {
-                    if (context.composingNewView) {
-                        if(context.parts){
-                            replaceParts(context);
-                        }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bindContext(context.bindingContext, child, context.model);
+                    if (context.binding) {
+                        context.binding(context.child, context.parent, context);
                     }
-                } else if (child) {
-                    var modelToBind = context.model || dummyModel;
-                    var currentModel = ko.dataFor(child);
 
-                    if (currentModel != modelToBind) {
-                        if (!context.composingNewView) {
-                            ko.removeNode(child);
-                            viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
-                                composition.bindAndShow(recreatedView, context, true);
-                            });
-                            return;
+                    if (context.preserveContext && context.bindingContext) {
+                        if (context.composingNewView) {
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bindContext(context.bindingContext, child, context.model);
                         }
+                    } else if (child) {
+                        var modelToBind = context.model || dummyModel;
+                        var currentModel = ko.dataFor(child);
 
-                        if(context.parts){
-                            replaceParts(context);
+                        if (currentModel != modelToBind) {
+                            if (!context.composingNewView) {
+                                ko.removeNode(child);
+                                viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
+                                    composition.bindAndShow(recreatedView, context, true);
+                                });
+                                return;
+                            }
+
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bind(modelToBind, child);
                         }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bind(modelToBind, child);
                     }
-                }
 
-                composition.finalize(context);
+                    composition.finalize(context);
+                } else {
+                    endComposition();
+                    cleanUp(context);
+                }
             }, skipActivation);
         },
         /**

--- a/platforms/Microsoft.NET/StarterKit/vstemplate/DurandalTemplate/DurandalTemplate/Scripts/durandal/composition.js
+++ b/platforms/Microsoft.NET/StarterKit/vstemplate/DurandalTemplate/DurandalTemplate/Scripts/durandal/composition.js
@@ -450,6 +450,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
         },
         bindAndShow: function (child, context, skipActivation) {
             context.child = child;
+            context.parent.__composition_context = context;
 
             if (context.cacheViews) {
                 context.composingNewView = (ko.utils.arrayIndexOf(context.viewElements, child) == -1);
@@ -458,46 +459,53 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
             }
 
             tryActivate(context, function () {
-                if (context.binding) {
-                    context.binding(context.child, context.parent, context);
-                }
+                if (context.parent.__composition_context == context) {
+                    delete context.parent.__composition_context;
 
-                if (context.preserveContext && context.bindingContext) {
-                    if (context.composingNewView) {
-                        if(context.parts){
-                            replaceParts(context);
-                        }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bindContext(context.bindingContext, child, context.model);
+                    if (context.binding) {
+                        context.binding(context.child, context.parent, context);
                     }
-                } else if (child) {
-                    var modelToBind = context.model || dummyModel;
-                    var currentModel = ko.dataFor(child);
 
-                    if (currentModel != modelToBind) {
-                        if (!context.composingNewView) {
-                            ko.removeNode(child);
-                            viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
-                                composition.bindAndShow(recreatedView, context, true);
-                            });
-                            return;
+                    if (context.preserveContext && context.bindingContext) {
+                        if (context.composingNewView) {
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bindContext(context.bindingContext, child, context.model);
                         }
+                    } else if (child) {
+                        var modelToBind = context.model || dummyModel;
+                        var currentModel = ko.dataFor(child);
 
-                        if(context.parts){
-                            replaceParts(context);
+                        if (currentModel != modelToBind) {
+                            if (!context.composingNewView) {
+                                ko.removeNode(child);
+                                viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
+                                    composition.bindAndShow(recreatedView, context, true);
+                                });
+                                return;
+                            }
+
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bind(modelToBind, child);
                         }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bind(modelToBind, child);
                     }
-                }
 
-                composition.finalize(context);
+                    composition.finalize(context);
+                } else {
+                    endComposition();
+                    cleanUp(context);
+                }
             }, skipActivation);
         },
         /**

--- a/platforms/Mimosa/StarterKit/assets/javascripts/vendor/durandal/composition.js
+++ b/platforms/Mimosa/StarterKit/assets/javascripts/vendor/durandal/composition.js
@@ -450,6 +450,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
         },
         bindAndShow: function (child, context, skipActivation) {
             context.child = child;
+            context.parent.__composition_context = context;
 
             if (context.cacheViews) {
                 context.composingNewView = (ko.utils.arrayIndexOf(context.viewElements, child) == -1);
@@ -458,46 +459,53 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
             }
 
             tryActivate(context, function () {
-                if (context.binding) {
-                    context.binding(context.child, context.parent, context);
-                }
+                if (context.parent.__composition_context == context) {
+                    delete context.parent.__composition_context;
 
-                if (context.preserveContext && context.bindingContext) {
-                    if (context.composingNewView) {
-                        if(context.parts){
-                            replaceParts(context);
-                        }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bindContext(context.bindingContext, child, context.model);
+                    if (context.binding) {
+                        context.binding(context.child, context.parent, context);
                     }
-                } else if (child) {
-                    var modelToBind = context.model || dummyModel;
-                    var currentModel = ko.dataFor(child);
 
-                    if (currentModel != modelToBind) {
-                        if (!context.composingNewView) {
-                            ko.removeNode(child);
-                            viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
-                                composition.bindAndShow(recreatedView, context, true);
-                            });
-                            return;
+                    if (context.preserveContext && context.bindingContext) {
+                        if (context.composingNewView) {
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bindContext(context.bindingContext, child, context.model);
                         }
+                    } else if (child) {
+                        var modelToBind = context.model || dummyModel;
+                        var currentModel = ko.dataFor(child);
 
-                        if(context.parts){
-                            replaceParts(context);
+                        if (currentModel != modelToBind) {
+                            if (!context.composingNewView) {
+                                ko.removeNode(child);
+                                viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
+                                    composition.bindAndShow(recreatedView, context, true);
+                                });
+                                return;
+                            }
+
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bind(modelToBind, child);
                         }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bind(modelToBind, child);
                     }
-                }
 
-                composition.finalize(context);
+                    composition.finalize(context);
+                } else {
+                    endComposition();
+                    cleanUp(context);
+                }
             }, skipActivation);
         },
         /**

--- a/src/durandal/js/composition.js
+++ b/src/durandal/js/composition.js
@@ -445,6 +445,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
         },
         bindAndShow: function (child, context, skipActivation) {
             context.child = child;
+            context.parent.__composition_context = context;
 
             if (context.cacheViews) {
                 context.composingNewView = (ko.utils.arrayIndexOf(context.viewElements, child) == -1);
@@ -453,46 +454,53 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
             }
 
             tryActivate(context, function () {
-                if (context.binding) {
-                    context.binding(context.child, context.parent, context);
-                }
+                if (context.parent.__composition_context == context) {
+                    delete context.parent.__composition_context;
 
-                if (context.preserveContext && context.bindingContext) {
-                    if (context.composingNewView) {
-                        if(context.parts){
-                            replaceParts(context);
-                        }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bindContext(context.bindingContext, child, context.model);
+                    if (context.binding) {
+                        context.binding(context.child, context.parent, context);
                     }
-                } else if (child) {
-                    var modelToBind = context.model || dummyModel;
-                    var currentModel = ko.dataFor(child);
 
-                    if (currentModel != modelToBind) {
-                        if (!context.composingNewView) {
-                            ko.removeNode(child);
-                            viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
-                                composition.bindAndShow(recreatedView, context, true);
-                            });
-                            return;
+                    if (context.preserveContext && context.bindingContext) {
+                        if (context.composingNewView) {
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bindContext(context.bindingContext, child, context.model);
                         }
+                    } else if (child) {
+                        var modelToBind = context.model || dummyModel;
+                        var currentModel = ko.dataFor(child);
 
-                        if(context.parts){
-                            replaceParts(context);
+                        if (currentModel != modelToBind) {
+                            if (!context.composingNewView) {
+                                ko.removeNode(child);
+                                viewEngine.createView(child.getAttribute('data-view')).then(function(recreatedView) {
+                                    composition.bindAndShow(recreatedView, context, true);
+                                });
+                                return;
+                            }
+
+                            if(context.parts){
+                                replaceParts(context);
+                            }
+
+                            hide(child);
+                            ko.virtualElements.prepend(context.parent, child);
+
+                            binder.bind(modelToBind, child);
                         }
-
-                        hide(child);
-                        ko.virtualElements.prepend(context.parent, child);
-
-                        binder.bind(modelToBind, child);
                     }
-                }
 
-                composition.finalize(context);
+                    composition.finalize(context);
+                } else {
+                    endComposition();
+                    cleanUp(context);
+                }
             }, skipActivation);
         },
         /**


### PR DESCRIPTION
This patch changes what happens if composition.compose is called, while
waiting for the activate callback to complete for an obsolete
composition context on the same parent element. The obsolete context is
ignored, and only the current (correct) context is applied.

Unfortunately, there's no way to abort the activate call for the
aborted composition, so we need to keep track of the state, so that we
can ignore the deferred callback on the obsolete state.

One unfortunate side-effect is that the compositionComplete callback is
called on both context, and only after the activate hooks for both
contexts are complete. So there might be a time gap after the activate
hook for the final correct state is finished, and the
compositionComplete is called.

(view patch with -w, --ignore-all-space)
