### PR TITLE
Fir for #473: Querystring function should only split on first '='

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -481,7 +481,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
                     continue;
                 }
 
-                var parts = pair.split('='),
+                var parts = pair.split(/=(.+)?/),
                     key = parts[0],
                     value = parts[1] && decodeURIComponent(parts[1].replace(/\+/g, ' '));
 


### PR DESCRIPTION
Currently if there are any '=' in the value of a param it will get
improperly split.

?token=1234==

Becomes

{ token: "1234" }

This fix should only split on the first instance. So the above example
should look like:

{ token: "1234==" }
