### PR TITLE
Fixed DurandalRouteConfiguration.nav to be optional in Typescript definition

### DIFF
--- a/src/typescript/durandal/durandal.d.ts
+++ b/src/typescript/durandal/durandal.d.ts
@@ -1384,7 +1384,7 @@ interface DurandalRouteConfiguration {
     route?: string;
     routePattern?: RegExp;
     isActive?: KnockoutComputed<boolean>;
-    nav:any;
+    nav?:any;
 }
 
 interface DurandalRouteInstruction {


### PR DESCRIPTION
According to the [Router documentation](http://durandaljs.com/documentation/Using-The-Router.html) a route configuration object `nav` property is supposed to be optional. This fixes the Typescript definition file to accordingly.
