### PR TITLE
Support full HTML templates

### DIFF
--- a/src/durandal/js/viewEngine.js
+++ b/src/durandal/js/viewEngine.js
@@ -35,6 +35,12 @@ define(['durandal/system', 'jquery'], function (system, $) {
          */
         viewPlugin: 'text',
         /**
+         * Parameters passed to the RequireJS loader plugin used by the viewLocator to obtain the view source.
+         * @property {string} viewPluginParameters
+         * @default !strip To allow html views to be a full HTML files
+         */
+        viewPluginParameters: '!strip',
+        /**
          * Determines if the url is a url for a view, according to the view engine.
          * @method isViewUrl
          * @param {string} url The potential view url.
@@ -59,7 +65,7 @@ define(['durandal/system', 'jquery'], function (system, $) {
          * @return {string} The require path.
          */
         convertViewIdToRequirePath: function (viewId) {
-            return this.viewPlugin + '!' + viewId + this.viewExtension;
+            return this.viewPlugin + '!' + viewId + this.viewExtension + this.viewPluginParameters;
         },
         /**
          * Parses the view engine recognized markup and returns DOM elements.


### PR DESCRIPTION
Allow viewEngine to load templates that are full HTML files by themselves

this allows for better template development, and does not affect the project after r optimization
