### PR TITLE
Add optional change detection

### DIFF
--- a/docs/2.x/Binding-Plain-Javascript-Objects.html.md
+++ b/docs/2.x/Binding-Plain-Javascript-Objects.html.md
@@ -113,3 +113,33 @@ In your view, you can data-bind to these as if they were normal arrays.
     <hr>
 </div>
 ```
+
+### Change Detection
+
+The observable module supports optional changed detection. To activate it, simply add the changeDetection parameter to the plugin activation:
+
+```javascript
+  app.configurePlugins({
+    observable: {
+      changeDetection: "hasChanged" // The name of your method.
+    },
+    // ... other plugins.
+  });
+```
+
+Then, add a method of the same name to your shell, model, viewmodel or controller:
+
+```javascript
+  hasChanged = function (obj, propertyName, newValue, arrayChanges) {
+    // obj is the object on which the property "propertyName" has changed.
+
+    if (arrayChanges) {
+      // Array changes needs version 3+ of Knockout and is called on changes
+      // to an observable array.
+    } else {
+      // newValue contains the new value of the observable having changed.
+    }
+  }
+```
+
+Multiple objects can receive notifications when changes are detected. Simply add the method to all the objects you need to detect those changes.

--- a/src/plugins/js/observable.js
+++ b/src/plugins/js/observable.js
@@ -229,7 +229,7 @@ define(['durandal/system', 'durandal/binder', 'knockout'], function(system, bind
             original.then(function (result) {
                 if(system.isArray(result)) {
                     var oa = ko.observableArray(result);
-                    makeObservableArray(result, oa);
+                    makeObservableArray(result, oa, hasChanged);
                     result = oa;
                 }
 


### PR DESCRIPTION
When using the observable plugin, add an option to register a method on each object to automatically detect changes. This method receives as parameters: the obj that has changed, the name of the changed property, and either the newValue if it's a value type, or the arrayChange object if it's an array.

For example, you could add an hasChanged(obj, propertyName, newValue, arrayChanged) function on the shell, and be notified any time a value changes on any module, so you can either save the value of update a dirty flag.

It's possible to register multiple methods (as long as the have the same name), so for example the shell could be notified to keep a global dirty flag for navigation, and the viewmodel could be notified to send the updated data to the server.
