### PR TITLE
Rewrite observable.innerSetter

### DIFF
--- a/src/plugins/js/observable.js
+++ b/src/plugins/js/observable.js
@@ -164,24 +164,22 @@ define(['durandal/system', 'durandal/binder', 'knockout'], function(system, bind
     }
 
     function innerSetter(observable, newValue, isArray) {
-        var val;
-        observable(newValue);
-        val = observable.peek();
-
         //if this was originally an observableArray, then always check to see if we need to add/replace the array methods (if newValue was an entirely new array)
         if (isArray) {
-            if (!val) {
+            if (!newValue) {
                 //don't allow null, force to an empty array
-                val = [];
-                observable(val);
-                makeObservableArray(val, observable);
+                newValue = [];
+                makeObservableArray(newValue, observable);
             }
-            else if (!val.destroyAll) {
-                makeObservableArray(val, observable);
+            else if (!newValue.destroyAll) {
+                makeObservableArray(newValue, observable);
             }
         } else {
-            convertObject(val);
+            convertObject(newValue);
         }
+
+        //call the update to the observable after the array as been updated.
+        observable(newValue);
     }
 
     /**


### PR DESCRIPTION
Reference BlueSpire/Durandal#496

Bug was, when replacing an array, the observable was updated (line 168) before the elements of the array were made observable (line 180). Since KnockOut updated the view as soon as we updated the observable, the link was broken for the elements of the array.

I'm not sure what the goal of peeking inside the observable at line 169 was. Everything seems to work just fine, but I didn't find any automated tests for that plugin, so please let me know if there was a specific reason for that code so we can find a workaround.

Also, I was trying to find a way to automate tests for cases like this. I haven't thought of a way yet besides building a dummy app, since I need to have a working view and viewmodel to test this complex scenario. If you have any idea, let me know.
