### PR TITLE
New "values" parameters for message boxes

### DIFF
--- a/docs/2.x/Showing-Message-Boxes-And-Modals.html.md
+++ b/docs/2.x/Showing-Message-Boxes-And-Modals.html.md
@@ -79,6 +79,20 @@ This message box will have two buttons "Yes" and "No". The yes button, which is 
 Notice also that a call to `showMessage` has a return value. This return value is actually a promise of the user's response. 
 It will be resolved when they select an option and the message box is closed.
 
+```javascript
+var screen = {
+  ...
+  canDeactivate:function(){
+    return app.showMessage('You have unsaved data. Are you sure you want to close?', 'Unsaved Data', ['Yes', 'No'], [true, false]);
+  }
+  ...
+};
+```
+
+This message box has the same buttons as the one before, but returns the values of the second array. The array can contain any object or value
+and the value is passed to the promise "done" handler according to the index of the button. If the array is smaller than the list of buttons,
+the text of the button will be used.
+
 ### Custom Dialogs
 
 It turns out that message boxes are just an implementation of a custom modal dialog.

--- a/src/plugins/js/dialog.js
+++ b/src/plugins/js/dialog.js
@@ -18,10 +18,11 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
      * Models a message box's message, title and options.
      * @class MessageBox
      */
-    var MessageBox = function(message, title, options) {
+    var MessageBox = function(message, title, options, values) {
         this.message = message;
         this.title = title || MessageBox.defaultTitle;
         this.options = options || MessageBox.defaultOptions;
+        this.values = values;
     };
 
     /**
@@ -29,8 +30,12 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
      * @method selectOption
      * @param {string} dialogResult The result to select.
      */
-    MessageBox.prototype.selectOption = function (dialogResult) {
-        dialog.close(this, dialogResult);
+    MessageBox.prototype.selectOption = function (index) {
+        if (this.values && this.values.length >= index) {
+            dialog.close(this, this.values[index])
+        } else {
+            dialog.close(this, this.options[index]);
+        }
     };
 
     /**
@@ -83,7 +88,7 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
                 '<p class="message" data-bind="text: message"></p>',
             '</div>',
             '<div class="modal-footer" data-bind="foreach: options">',
-                '<button class="btn" data-bind="click: function () { $parent.selectOption($data); }, text: $data, css: { \'btn-primary\': $index() == 0, autofocus: $index() == 0 }"></button>',
+                '<button class="btn" data-bind="click: function () { $parent.selectOption($index()); }, text: $data, css: { \'btn-primary\': $index() == 0, autofocus: $index() == 0 }"></button>',
             '</div>',
         '</div>'
     ].join('\n');
@@ -262,16 +267,17 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
          * @param {string[]} [options] The options to provide to the user.
          * @return {Promise} A promise that resolves when the message box is closed and returns the selected option.
          */
-        showMessage:function(message, title, options){
+        showMessage:function(message, title, options, values){
             if(system.isString(this.MessageBox)){
                 return dialog.show(this.MessageBox, [
                     message,
                     title || MessageBox.defaultTitle,
-                    options || MessageBox.defaultOptions
+                    options || MessageBox.defaultOptions,
+                    values
                 ]);
             }
 
-            return dialog.show(new this.MessageBox(message, title, options));
+            return dialog.show(new this.MessageBox(message, title, options, values));
         },
         /**
          * Installs this module into Durandal; called by the framework. Adds `app.showDialog` and `app.showMessage` convenience methods.
@@ -283,8 +289,8 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
                 return dialog.show(obj, activationData, context);
             };
 
-            app.showMessage = function(message, title, options) {
-                return dialog.showMessage(message, title, options);
+            app.showMessage = function(message, title, options, values) {
+                return dialog.showMessage(message, title, options, values);
             };
 
             if(config.messageBox){

--- a/src/typescript/durandal/durandal.d.ts
+++ b/src/typescript/durandal/durandal.d.ts
@@ -1183,9 +1183,10 @@ interface DurandalAppModule extends DurandalEventSupport<DurandalAppModule> {
      * @param {string} message The message to display in the dialog.
      * @param {string} [title] The title message.
      * @param {string[]} [options] The options to provide to the user.
+     * @param {object[]} [values] The values to return to the caller.
      * @returns {Promise} A promise that resolves when the message box is closed and returns the selected option.
     */
-    showMessage(message: string, title?: string, options?: string[]): JQueryPromise<string>;
+    showMessage(message: string, title?: string, options?: string[], values?: any[]): JQueryPromise<string>;
 
     /**
      * Configures one or more plugins to be loaded and installed into the application.


### PR DESCRIPTION
Sometimes it's useful to get a value instead of the text of the button
when returning from a dialog. 2 examples are when translating an
application (you don't want to write your logic according to the text of
the button) or when you want to chose between 2 objects with a dialog.

I hesitated between this and passing objects with both a text and a
value properties in the third parameter. Normally I try to stay away
from parallel arrays, but in this case I think it's easier to update
existing code, plus if the arrays are not of the same length it's not
critical (we pass the text of the button if the 2nd array is shorter,
and we'll never return the value if it's longer).
