### PR TITLE
Don't enforce viewPlugin

### DIFF
--- a/src/durandal/js/viewEngine.js
+++ b/src/durandal/js/viewEngine.js
@@ -65,7 +65,8 @@ define(['durandal/system', 'jquery'], function (system, $) {
          * @return {string} The require path.
          */
         convertViewIdToRequirePath: function (viewId) {
-            return this.viewPlugin + '!' + viewId + this.viewExtension + this.viewPluginParameters;
+            var plugin = this.viewPlugin ? this.viewPlugin + '!' : '';
+            return plugin + viewId + this.viewExtension + this.viewPluginParameters;
         },
         /**
          * Parses the view engine recognized markup and returns DOM elements.


### PR DESCRIPTION
Allow viewEngine to be `falsey` without prepending the `!` character to RequireJS paths
