### PR TITLE
Ensuring that composition show never inadvertently hides elements

### DIFF
--- a/src/durandal/js/composition.js
+++ b/src/durandal/js/composition.js
@@ -228,7 +228,8 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
     }
 
     function show(view) {
-        view.style.display = ko.utils.domData.get(view, visibilityKey);
+        var displayStyle = ko.utils.domData.get(view, visibilityKey);
+        view.style.display = displayStyle === 'none' ? 'block' : displayStyle;
     }
 
     function hasComposition(element){


### PR DESCRIPTION
See comment on https://github.com/BlueSpire/Durandal/commit/cf62ba59bcb0dcb3951db74442133592d540be48 

This will ensure that the show function never sets an element to `display:none`
