### PR TITLE
Made dialog.isOpen computed

### DIFF
--- a/src/plugins/js/dialog.js
+++ b/src/plugins/js/dialog.js
@@ -11,7 +11,7 @@
  */
 define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/activator', 'durandal/viewEngine', 'jquery', 'knockout'], function (system, app, composition, activator, viewEngine, $, ko) {
     var contexts = {},
-        dialogCount = 0,
+        dialogCount = ko.observable(0),
         dialog;
 
     /**
@@ -217,9 +217,9 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
          * @method isOpen
          * @return {boolean} True if a dialog is open. false otherwise.
          */
-        isOpen: function () {
-            return dialogCount > 0;
-        },
+        isOpen: ko.computed( function () {
+            return dialogCount() > 0;
+        } ),
         /**
          * Gets the dialog context by name or returns the default context if no name is specified.
          * @method getContext
@@ -317,7 +317,7 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
                                     var args = arguments;
                                     dialogActivator.deactivateItem(instance, true).then(function (closeSuccess) {
                                         if (closeSuccess) {
-                                            dialogCount--;
+                                            dialogCount(dialogCount() - 1);
                                             dialogContext.removeHost(theDialog);
                                             delete instance.__dialog__;
 
@@ -336,7 +336,7 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
                             theDialog.settings = that.createCompositionSettings(instance, dialogContext);
                             dialogContext.addHost(theDialog);
 
-                            dialogCount++;
+                            dialogCount(dialogCount() + 1);
                             composition.compose(theDialog.host, theDialog.settings);
                         } else {
                             dfd.resolve(false);


### PR DESCRIPTION
I have a full-screen loading animation that I have hooked into router.isNavigating (which is observable), but I would also like to hook into dialog.isOpen so that I can hide the loading animation if a dialog is shown (for example, when confirming deactivation).

Therefore, I simply changed dialogCount to be ko.observable and updated all instances of dialogCount, then wrapped the isOpen function with ko.computed.  

I am now able to hook into/bind to isOpen and hide the loading animation when isOpen is true.
