### PR TITLE
Fix #545: navigation breaks after failing to load module

### DIFF
--- a/platforms/Bower/Durandal/js/plugins/router.js
+++ b/platforms/Bower/Durandal/js/plugins/router.js
@@ -433,6 +433,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                     ensureActivation(activeItem, instance, instruction);
                 }).fail(function(err) {
+                    cancelNavigation(null, instruction);
                     system.error('Failed to load routed module (' + instruction.config.moduleId + '). Details: ' + err.message, err);
                 });
             }

--- a/platforms/HTML/Samples/lib/durandal/js/plugins/router.js
+++ b/platforms/HTML/Samples/lib/durandal/js/plugins/router.js
@@ -433,6 +433,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                     ensureActivation(activeItem, instance, instruction);
                 }).fail(function(err) {
+                    cancelNavigation(null, instruction);
                     system.error('Failed to load routed module (' + instruction.config.moduleId + '). Details: ' + err.message, err);
                 });
             }

--- a/platforms/HTML/StarterKit/lib/durandal/js/plugins/router.js
+++ b/platforms/HTML/StarterKit/lib/durandal/js/plugins/router.js
@@ -433,6 +433,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                     ensureActivation(activeItem, instance, instruction);
                 }).fail(function(err) {
+                    cancelNavigation(null, instruction);
                     system.error('Failed to load routed module (' + instruction.config.moduleId + '). Details: ' + err.message, err);
                 });
             }

--- a/platforms/Microsoft.NET/Nuget/Durandal.Transitions/content/Scripts/durandal/plugins/router.js
+++ b/platforms/Microsoft.NET/Nuget/Durandal.Transitions/content/Scripts/durandal/plugins/router.js
@@ -433,6 +433,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                     ensureActivation(activeItem, instance, instruction);
                 }).fail(function(err) {
+                    cancelNavigation(null, instruction);
                     system.error('Failed to load routed module (' + instruction.config.moduleId + '). Details: ' + err.message, err);
                 });
             }

--- a/platforms/Microsoft.NET/Nuget/Durandal/content/Scripts/durandal/plugins/router.js
+++ b/platforms/Microsoft.NET/Nuget/Durandal/content/Scripts/durandal/plugins/router.js
@@ -433,6 +433,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                     ensureActivation(activeItem, instance, instruction);
                 }).fail(function(err) {
+                    cancelNavigation(null, instruction);
                     system.error('Failed to load routed module (' + instruction.config.moduleId + '). Details: ' + err.message, err);
                 });
             }

--- a/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/plugins/router.js
+++ b/platforms/Microsoft.NET/Samples/Durandal.Samples/Scripts/durandal/plugins/router.js
@@ -433,6 +433,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                     ensureActivation(activeItem, instance, instruction);
                 }).fail(function(err) {
+                    cancelNavigation(null, instruction);
                     system.error('Failed to load routed module (' + instruction.config.moduleId + '). Details: ' + err.message, err);
                 });
             }

--- a/platforms/Mimosa/StarterKit/assets/javascripts/vendor/durandal/plugins/router.js
+++ b/platforms/Mimosa/StarterKit/assets/javascripts/vendor/durandal/plugins/router.js
@@ -433,6 +433,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                     ensureActivation(activeItem, instance, instruction);
                 }).fail(function(err) {
+                    cancelNavigation(null, instruction);
                     system.error('Failed to load routed module (' + instruction.config.moduleId + '). Details: ' + err.message, err);
                 });
             }

--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -428,6 +428,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                     ensureActivation(activeItem, instance, instruction);
                 }).fail(function(err) {
+                    cancelNavigation(null, instruction);
                     system.error('Failed to load routed module (' + instruction.config.moduleId + '). Details: ' + err.message, err);
                 });
             }


### PR DESCRIPTION
Now calls `cancelNavigation` when failing to load a routed module. Passes `null` for `instance` parameter since we don't have that on a failure.
