### PR TITLE
Update Gulp.html.md

### DIFF
--- a/docs/2.x/Gulp.html.md
+++ b/docs/2.x/Gulp.html.md
@@ -52,7 +52,7 @@ gulp.task('durandal', function(){
     durandal({
             baseDir: 'app',   //same as default, so not really required.
             main: 'main.js',  //same as default, so not really required.
-            output: 'main.js', //same as default, so not really required.
+            output: 'main-built.js',
             almond: true,
             minify: true
         })


### PR DESCRIPTION
The input is the same name as the output filename for the build; that means once gulp is done building, it will overwrite main.js with the build results. Updated the output to be main-built.js as per Durandal convention.
