### PR TITLE
Fix back-button not working after cancelled navigation

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -264,7 +264,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
             router.activeInstruction(currentInstruction);
 
-            router.navigate(lastUrl, false);
+            router.navigate(lastUrl, {trigger: false, replace: true});
 
             isProcessing(false);
             rootRouter.explicitNavigation = false;


### PR DESCRIPTION
Added the 'replace' option to the navigation that happens back to the
original route, after some other navigation fails. This prevents the
failed location to be added to the browser history, causing the
back-button to retry the failed navigation in an endless loop.
