### PR TITLE
Dialog: Fix height issues when calling reposition

### DIFF
--- a/src/plugins/js/dialog.js
+++ b/src/plugins/js/dialog.js
@@ -525,6 +525,10 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
             if (!$view.data("predefinedWidth")) {
                 $view.css({ width: '' }); //Reset width
             }
+            
+            // clear the height
+            $view.css({ height: '' });
+
             var width = $view.outerWidth(false),
                 height = $view.outerHeight(false),
                 windowHeight = $window.height() - 10, //leave at least 10 pixels free


### PR DESCRIPTION
This commit fixes an issue where if reposition is called more than once, the height of the dialog is changed on the first call and affects the calculations in subsequent calls such that for dialogs that exceed the window height, vertical scrollbars are removed erroneously.
