### PR TITLE
Memory leak: items not deactivating

### DIFF
--- a/src/durandal/js/activator.js
+++ b/src/durandal/js/activator.js
@@ -112,6 +112,7 @@ define(['durandal/system', 'knockout'], function (system, ko) {
                 callback(true);
             }, function(reason) {
                 system.log('ERROR: ' + reason.message, reason);
+                activeItem(newItem);
                 callback(false);
             });
         } else {


### PR DESCRIPTION
When navigation is canceled (or redirected) during an async activate, the old item is deactivated twice and the new item is not deactivated at all.