### PR TITLE
Fix issue #556: issue with objects in activeInstruction params

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -597,7 +597,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
             if(router.relativeToParentRouter){
                 var instruction = this.parent.activeInstruction();
-				coreFragment = queryIndex == -1 ? instruction.params.join('/') : instruction.params.slice(0, -1).join('/');
+				coreFragment = (queryIndex == -1 ? instruction.params : instruction.params.slice(0, -1)).filter(function(param){return typeof param === 'string'}).join('/');
 
                 if(coreFragment && coreFragment.charAt(0) == '/'){
                     coreFragment = coreFragment.substr(1);


### PR DESCRIPTION
As referenced in [issue 556](https://github.com/BlueSpire/Durandal/issues/556), here is a pull request based on my original suggestion from July, based on the current state of router.js.
