### PR TITLE
docs: updated knockout version

### DIFF
--- a/docs/2.x/get-started.html.md
+++ b/docs/2.x/get-started.html.md
@@ -58,7 +58,7 @@ requirejs.config({
     'durandal':'../lib/durandal/js',
     'plugins' : '../lib/durandal/js/plugins',
     'transitions' : '../lib/durandal/js/transitions',
-    'knockout': '../lib/knockout/knockout-2.3.0',
+    'knockout': '../lib/knockout/knockout-3.1.0',
     'jquery': '../lib/jquery/jquery-1.9.1'
     } 
 });


### PR DESCRIPTION
updated example code from knockout-2.3.0 to knockout-3.1.0, which is the current version included in the Getting Started Kit. The former code causes a script error.