### PR TITLE
Revise main.js citation

### DIFF
--- a/docs/2.x/get-started.html.md
+++ b/docs/2.x/get-started.html.md
@@ -58,7 +58,7 @@ requirejs.config({
     'durandal':'../lib/durandal/js',
     'plugins' : '../lib/durandal/js/plugins',
     'transitions' : '../lib/durandal/js/transitions',
-    'knockout': '../lib/knockout/knockout-2.3.0',
+    'knockout': '../lib/knockout/knockout-3.1.0',
     'jquery': '../lib/jquery/jquery-1.9.1'
     } 
 });


### PR DESCRIPTION
Revise main.js citation to match actual /lib contents as shipped with StarterKit zip.
![selection_082](https://cloud.githubusercontent.com/assets/1242423/5153610/04ee0a2a-71e5-11e4-8a3f-91b68b9c2a96.png)
