### PR TITLE
Update router.js

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -1080,10 +1080,11 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
     };
 
     /**
-     * Disable history, perhaps temporarily. Not useful in a real app, but possibly useful for unit testing Routers.
+     * Deactivate current items and turn history listening off.
      * @method deactivate
      */
     rootRouter.deactivate = function() {
+        rootRouter.activeItem(null);
         history.deactivate();
     };
 


### PR DESCRIPTION
enhanced deactivate to close #605

the app library does not depend on the router and therefore cannot be responsible for the activator lifecycle. it makes the most sense to add a "disable current item" on the "disable router" function that can be called before setting a new root.