### PR TITLE
Composition: To hide and show, set visibility not display:none

### DIFF
--- a/src/durandal/js/composition.js
+++ b/src/durandal/js/composition.js
@@ -18,7 +18,6 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
         compositionDataKey = 'durandal-composition-data',
         partAttributeName = 'data-part',
         bindableSettings = ['model', 'view', 'transition', 'area', 'strategy', 'activationData', 'onError'],
-        visibilityKey = "durandal-visibility-data",
         composeBindings = ['compose:'];
     
     function onError(context, error, element) {
@@ -232,13 +231,11 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
     }
 
     function hide(view) {
-        ko.utils.domData.set(view, visibilityKey, view.style.display);
-        view.style.display = 'none';
+        view.style.visibility = 'hidden';
     }
 
     function show(view) {
-        var displayStyle = ko.utils.domData.get(view, visibilityKey);
-        view.style.display = displayStyle === 'none' ? 'block' : displayStyle;
+        view.style.visibility = 'visible';
     }
 
     function hasComposition(element){


### PR DESCRIPTION
When knockout bindings are executing during composition the view is currently display:none
This causes an issue if you need to calculate the width of elements on the page.  

In my case I was trying to use blockUI to mask an area of the view which loads after the view is attached.  BlockUI uses the element's width/height to center itself in the element.  

The proposed change merely changes the composition engine to set visibility instead of display none, and I also removed the calls to set knockout domdata since I searched the codebase and this was the only use of it and it doesn't make sense to use when the css property has only 2 possibilities.
