### PR TITLE
hide view AFTER knockout binding

### DIFF
--- a/src/durandal/js/composition.js
+++ b/src/durandal/js/composition.js
@@ -497,10 +497,10 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
                                 replaceParts(context);
                             }
 
-                            hide(child);
                             ko.virtualElements.prepend(context.parent, child);
 
-                        binder.bindContext(context.bindingContext, child, context.model, context.as);
+                            binder.bindContext(context.bindingContext, child, context.model, context.as);
+                            hide(child);
                         }
                     } else if (child) {
                         var modelToBind = context.model || dummyModel;
@@ -519,10 +519,10 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
                                 replaceParts(context);
                             }
 
-                            hide(child);
                             ko.virtualElements.prepend(context.parent, child);
 
                             binder.bind(modelToBind, child);
+                            hide(child);
                         }
                     }
 


### PR DESCRIPTION
Reference #611

Visibility is not very animation friendly, the previous edit worked but broke all transitions.
In this edit, I moved the hide view call to AFTER calling knockout's bind, which means the knockout binding handlers will have an element with width/height AND display:none is used to transitions are happy.
