### PR TITLE
Resolve the problem that empty URL parameters are removed

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -549,7 +549,7 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                 var parts = pair.split(/=(.+)?/),
                     key = parts[0],
-                    value = parts[1] && decodeURIComponent(parts[1].replace(/\+/g, ' '));
+                    value = (parts[1] && decodeURIComponent(parts[1].replace(/\+/g, ' '))) || null;
 
                 var existing = queryObject[key];
 


### PR DESCRIPTION
The problem is described in details here:
https://github.com/BlueSpire/Durandal/issues/625

After this fix, empty URL parameters are passed as null to the controller.