### PR TITLE
[Fix] Consistently provide the second `error` argument to system.log

### DIFF
--- a/src/durandal/js/app.js
+++ b/src/durandal/js/app.js
@@ -38,7 +38,7 @@ define(['durandal/system', 'durandal/viewEngine', 'durandal/composition', 'duran
 
                 dfd.resolve();
             }).fail(function(err){
-                system.error('Failed to load plugin(s). Details: ' + err.message);
+                system.error('Failed to load plugin(s). Details: ' + err.message, err);
             });
         }).promise();
     }
@@ -137,8 +137,8 @@ define(['durandal/system', 'durandal/viewEngine', 'durandal/composition', 'duran
                             } else if (result) {
                                 composition.compose(hostElement, settings);
                             }
-                        } catch (er) {
-                            system.error(er);
+                        } catch (err) {
+                            system.error(err);
                         }
                     } else {
                         composition.compose(hostElement, settings);
@@ -153,7 +153,7 @@ define(['durandal/system', 'durandal/viewEngine', 'durandal/composition', 'duran
                     settings.model = system.resolveObject(module);
                     finishComposition();
                 }).fail(function(err) {
-                    system.error('Failed to load root module (' + settings.model + '). Details: ' + err.message);
+                    system.error('Failed to load root module (' + settings.model + '). Details: ' + err.message, err);
                 });
             } else {
                 finishComposition();

--- a/src/durandal/js/binder.js
+++ b/src/durandal/js/binder.js
@@ -73,12 +73,12 @@ define(['durandal/system', 'knockout'], function (system, ko) {
 
             ko.utils.domData.set(view, bindingInstructionKey, instruction);
             return instruction;
-        } catch (e) {
-            e.message = e.message + ';\nView: ' + viewName + ";\nModuleId: " + system.getModuleId(data);
+        } catch (err) {
+            err.message = err.message + ';\nView: ' + viewName + ";\nModuleId: " + system.getModuleId(data);
             if (binder.throwOnErrors) {
-                system.error(e);
+                system.error(err);
             } else {
-                system.log(e.message);
+                system.log(err.message);
             }
         }
     }

--- a/src/durandal/js/composition.js
+++ b/src/durandal/js/composition.js
@@ -21,16 +21,16 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
         visibilityKey = "durandal-visibility-data",
         composeBindings = ['compose:'];
     
-    function onError(context, error, element) {
+    function onError(context, reason, element, error) {
         try {
             if (context.onError) {
                 try {
-                    context.onError(error, element);
+                    context.onError(reason, element, error);
                 } catch (e) {
-                    system.error(e);
+                    system.error(e, error);
                 }
             } else {
-                system.error(error);
+                system.error(reason, error);
             }
         } finally {
             endComposition(context, element, true);
@@ -443,7 +443,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
                         endComposition(context, element);
                     });
                 }).fail(function(err){
-                    onError(context, 'Failed to load transition (' + transitionModuleId + '). Details: ' + err.message, element);
+                    onError(context, 'Failed to load transition (' + transitionModuleId + '). Details: ' + err.message, element, err);
                 });
             } else {
                 if (context.child != context.activeView) {
@@ -624,7 +624,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
                     context.strategy = strategy;
                     composition.executeStrategy(context, element);
                 }).fail(function (err) {
-                    onError(context, 'Failed to load view strategy (' + context.strategy + '). Details: ' + err.message, element);
+                    onError(context, 'Failed to load view strategy (' + context.strategy + '). Details: ' + err.message, element, err);
                 });
             } else {
                 this.executeStrategy(context, element);
@@ -683,7 +683,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
                     settings.model = system.resolveObject(module);
                     composition.inject(settings, element);
                 }).fail(function (err) {
-                    onError(settings, 'Failed to load composed module (' + settings.model + '). Details: ' + err.message, element);
+                    onError(settings, 'Failed to load composed module (' + settings.model + '). Details: ' + err.message, element, err);
                 });
             } else {
                 composition.inject(settings, element);

--- a/src/plugins/js/dialog.js
+++ b/src/plugins/js/dialog.js
@@ -181,7 +181,7 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
                 system.acquire(objOrModuleId).then(function (module) {
                     dfd.resolve(system.resolveObject(module));
                 }).fail(function (err) {
-                    system.error('Failed to load dialog module (' + objOrModuleId + '). Details: ' + err.message);
+                    system.error('Failed to load dialog module (' + objOrModuleId + '). Details: ' + err.message, err);
                 });
             } else {
                 dfd.resolve(objOrModuleId);


### PR DESCRIPTION
In cases where `system.error` is used, ensure that the second parameter is the actual error that was generated (where possible). This ensures we always have access to the real stack trace of where the error happened for tracking/debugging purposes
