### PR TITLE
feat(viewEngine.js): add guard for importing empty views

### DIFF
--- a/src/durandal/js/viewEngine.js
+++ b/src/durandal/js/viewEngine.js
@@ -93,7 +93,9 @@ define(['durandal/system', 'jquery'], function (system, $) {
          * @return {DOMElement} A single element.
          */
         ensureSingleElement:function(allElements){
-            if (allElements.length == 1) {
+            if (!allElements) { 
+                $('<div></div>')[0];
+            } else if (allElements.length == 1) {
                 return allElements[0];
             }
 


### PR DESCRIPTION
Added code to check for an empty view and create an empty element to treat as the view. This prevents unnecessary errors in the activation lifecycle.

closes #614