### PR TITLE
Fix for issue 654.

### DIFF
--- a/src/plugins/js/observable.js
+++ b/src/plugins/js/observable.js
@@ -344,7 +344,12 @@ define(['durandal/system', 'durandal/binder', 'knockout'], function(system, bind
         }
 
         computed = ko.computed(computedOptions);
-        obj[propertyName] = computed;
+
+        Object.defineProperty(obj, propertyName, {
+            configurable: true,
+            enumerable: true,
+            value: computed
+        });
 
         return convertProperty(obj, propertyName, computed);
     }


### PR DESCRIPTION
Using Object.defineProperty in observable.defineProperty when setting the computed observable on the object, so we avoid the setter if there is one.