### PR TITLE
fix for #658

### DIFF
--- a/src/durandal/js/composition.js
+++ b/src/durandal/js/composition.js
@@ -483,7 +483,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
                 context.composingNewView = true;
             }
 
-            tryActivate(context, function () {
+            ko.ignoreDependencies(tryActivate, null, [context, function () {
                 if (context.parent.__composition_context == context) {
                     try {
                         delete context.parent.__composition_context;
@@ -535,7 +535,7 @@ define(['durandal/system', 'durandal/viewLocator', 'durandal/binder', 'durandal/
                 } else {
                     endComposition(context, element);
                 }
-            }, skipActivation, element);
+            }, skipActivation, element]);
         },
         /**
          * Eecutes the default view location strategy.


### PR DESCRIPTION
It seems the tryActivate function is a source point for every possible callback. In order to prevent taking dependencies on observables accessed in that callbacks, the call should be wrapped into ko.ignoreDependencies.
