### PR TITLE
added missing dynamicHash property to RelativeRouteSettings interface

### DIFF
--- a/src/typescript/durandal/durandal.d.ts
+++ b/src/typescript/durandal/durandal.d.ts
@@ -1459,6 +1459,7 @@ declare module 'durandal/typescript' {
         moduleId?: string;
         route?: string;
         fromParent?: boolean;
+		dynamicHash?: string;
     }
 
     export interface Router {


### PR DESCRIPTION
added missing dynamicHash property to RelativeRouteSettings interface that was causing compilation error in TS 1.6
