### PR TITLE
Making dialog JQuery 3.x compliant

### DIFF
--- a/src/plugins/js/dialog.js
+++ b/src/plugins/js/dialog.js
@@ -504,7 +504,7 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
             };
 
             setDialogPosition(child, theDialog);
-            loadables.load(function () {
+            loadables.on("load", function () {
                 setDialogPosition(child, theDialog);
             });
 


### PR DESCRIPTION
Jquery deleted .load in 3.x, recomended to use .on("load" instead.

https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed