### PR TITLE
Grand child routers parents isNavigation is false

### DIFF
--- a/src/plugins/js/router.js
+++ b/src/plugins/js/router.js
@@ -255,8 +255,6 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
             rootRouter.explicitNavigation = false;
             rootRouter.navigatingBack = false;
-
-            router.trigger('router:navigation:complete', instance, instruction, router);
         }
 
         function cancelNavigation(instance, instruction) {
@@ -319,6 +317,9 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
 
                         instance.router.loadUrl(fullFragment);
                     }
+
+	            isProcessing(false);
+                    router.trigger('router:navigation:complete', instance, instruction, router);
 
                     if (previousActivation == instance) {
                         router.attached();
@@ -724,7 +725,6 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
         };
 
         router.compositionComplete = function(){
-            isProcessing(false);
             router.trigger('router:navigation:composition-complete', currentActivation, currentInstruction, router);
             dequeueInstruction();
         };


### PR DESCRIPTION
When having 3 or more routers involved in a router, then isNavigation for the root will change to false after the 1st child routers view has composition complete. It should not register completed until we have seen if there is a child router that also needs to process additional routing information.