### PR TITLE
minor change to messageBox default

### DIFF
--- a/src/plugins/js/dialog.js
+++ b/src/plugins/js/dialog.js
@@ -72,7 +72,7 @@ define(['durandal/system', 'durandal/app', 'durandal/composition', 'durandal/act
     MessageBox.defaultOptions = ['Ok'];
 
     
-    MessageBox.defaultSettings = { buttonClass: "btn btn-default", primaryButtonClass: "btn-primary autofocus", secondaryButtonClass: "", "class": "modal-content messageBox", style: null };
+    MessageBox.defaultSettings = { buttonClass: "btn", primaryButtonClass: "btn-primary autofocus", secondaryButtonClass: "", "class": "modal-content messageBox", style: null };
 
     /**
     * Sets the classes and styles used throughout the message box markup.


### PR DESCRIPTION
The default messagebox code applies both the btn-default and btn-primary classes to the primary button. This is not desirable to have both classes on a single button (in my case, there was a blue background from btn-primary with black text from btn-default).