### PR TITLE
Cross-browser fix in history's checkUrl

### DIFF
--- a/src/plugins/js/history.js
+++ b/src/plugins/js/history.js
@@ -175,17 +175,40 @@ define(['durandal/system', 'jquery'], function (system, $) {
     };
 
     /**
+     * Cleans a given URL fragment so that history.fragment can be safely compared with history.getHash
+     * The characters replaced are: `~!*()'-._`
+     * Based on http://www.justarrangingbits.org/firefox-magic-decoding-address-bar/index.html
+     * @method cleanFragment
+     * @return {string} Returns a string with normalized characters.
+     */
+    function cleanFragment(s) {
+        return (s || "")
+            .replace(/~/g,   "%7E")
+            .replace(/!/g,   "%21")
+            .replace(/\*/g,  "%2A")
+            .replace(/\(/g,  "%28")
+            .replace(/\)/g,  "%29")
+            .replace(/'/g,   "%27")
+            .replace(/-/g,   "%2D")
+            .replace(/\./g,  "%2E")
+            .replace(/_/g,   "%5F");
+    }
+    
+    /**
      * Checks the current URL to see if it has changed, and if it has, calls `loadUrl`, normalizing across the hidden iframe.
      * @method checkUrl
      * @return {boolean} Returns true/false from loading the url.
      */
     history.checkUrl = function() {
         var current = history.getFragment();
-        if (current === history.fragment && history.iframe) {
+        var currentFragment = cleanFragment(current);
+        var historyFragment = cleanFragment(history.fragment);
+
+        if (currentFragment === historyFragment && history.iframe) {
             current = history.getFragment(history.getHash(history.iframe));
         }
 
-        if (current === history.fragment) {
+        if (currentFragment === historyFragment) {
             return false;
         }
 

--- a/src/plugins/js/history.js
+++ b/src/plugins/js/history.js
@@ -175,47 +175,26 @@ define(['durandal/system', 'jquery'], function (system, $) {
     };
 
     /**
-     * Cleans a given URL fragment so that history.fragment can be safely compared with history.getHash
-     * The characters replaced are: `~!*()'-._`
-     * Based on http://www.justarrangingbits.org/firefox-magic-decoding-address-bar/index.html
-     * @method cleanFragment
-     * @return {string} Returns a string with normalized characters.
-     */
-    function cleanFragment(s) {
-        return (s || "")
-            .replace(/~/g,   "%7E")
-            .replace(/!/g,   "%21")
-            .replace(/\*/g,  "%2A")
-            .replace(/\(/g,  "%28")
-            .replace(/\)/g,  "%29")
-            .replace(/'/g,   "%27")
-            .replace(/-/g,   "%2D")
-            .replace(/\./g,  "%2E")
-            .replace(/_/g,   "%5F");
-    }
-    
-    /**
      * Checks the current URL to see if it has changed, and if it has, calls `loadUrl`, normalizing across the hidden iframe.
      * @method checkUrl
      * @return {boolean} Returns true/false from loading the url.
      */
     history.checkUrl = function() {
         var current = history.getFragment();
-        var currentFragment = cleanFragment(current);
-        var historyFragment = cleanFragment(history.fragment);
+        var currentIsFragment = decodeURIComponent(current) === decodeURIComponent(history.fragment);
 
-        if (currentFragment === historyFragment && history.iframe) {
+        if (currentIsFragment && history.iframe) {
             current = history.getFragment(history.getHash(history.iframe));
         }
 
-        if (currentFragment === historyFragment) {
+        if (currentIsFragment) {
             return false;
         }
 
         if (history.iframe) {
             history.navigate(current, false);
         }
-        
+
         history.loadUrl();
     };
     


### PR DESCRIPTION
There are some edge cases (that we've experienced) in which even if
`history.fragment` should be equal to `getFragment()` result, it
doesn't match because some characters aren't properly encoded. This behavior happens even if `getFragment()` gets to use `history.getHash()`.

In this PR I'm proposing a change that fixes this problem for us. The characters being replaced
are based on those reported in this website: <http://www.justarrangingbits.org/firefox-magic-decoding-address-bar/index.html> under the section `Characters not encoded by encodeUriComponent, but shown decoded in the address bar by Firefox`. The mentioned website doesn't relate to history's fragments or other properties, but between all the group of characters that are interpreted differently, this set is the only one that matches the scenarios that we've experienced.

The Durandal version used in our platform: 2.1.0.

I haven't had the chance to make an isolated example to reproduce this problem, I will be doing that. However, if anyone could give me more feedback about this solution attempt or any related knowledge you might have, I would appreciate it.